### PR TITLE
Migrate multi listing submissions

### DIFF
--- a/lib/tasks/one_time.rake
+++ b/lib/tasks/one_time.rake
@@ -3,16 +3,17 @@ require_relative './support/listing_converter'
 namespace :one_time do
   desc "split listings with multiple tags into one listing for each tag"
   task split_listings: :environment do
+    converter = ListingConverter.new
+
     relevant_listings = Listing.joins(:taggings).group('listings.id').having('count(taggable_id) > 1')
-    puts "Processing #{relevant_listings.count} listings"
+    puts "Processing #{relevant_listings.count.keys.size} listings"
 
     relevant_listings.find_each do |listing|
-      puts "--, #{listing.id}, #{listing.tag_list}"
-      new_listings = ListingConverter.new(listing).convert
+      puts "#, #{listing.id}, #{listing.tag_list}"
+      new_listings = converter.convert listing
 
-      new_listings.each do |new_listing|
-        puts "++, #{new_listing.id}, #{new_listing.tag_list}"
-      end
+      puts "-, #{listing.id}, #{listing.reload.tag_list}"
+      new_listings.each{ |new_listing| puts "+, #{new_listing.id}, #{new_listing.tag_list}" }
     end
   end
 end

--- a/lib/tasks/one_time.rake
+++ b/lib/tasks/one_time.rake
@@ -1,0 +1,18 @@
+require_relative './support/listing_converter'
+
+namespace :one_time do
+  desc "split listings with multiple tags into one listing for each tag"
+  task split_listings: :environment do
+    relevant_listings = Listing.joins(:taggings).group('listings.id').having('count(taggable_id) > 1')
+    puts "Processing #{relevant_listings.count} listings"
+
+    relevant_listings.find_each do |listing|
+      puts "--, #{listing.id}, #{listing.tag_list}"
+      new_listings = ListingConverter.new(listing).convert
+
+      new_listings.each do |new_listing|
+        puts "++, #{new_listing.id}, #{new_listing.tag_list}"
+      end
+    end
+  end
+end

--- a/lib/tasks/support/listing_converter.rb
+++ b/lib/tasks/support/listing_converter.rb
@@ -1,24 +1,45 @@
 class ListingConverter
-  attr_reader :listing
-
-  def initialize listing
-    @listing = listing
-  end
-
-  def convert
+  def convert listing
     Listing.transaction do
-      first_tag, *tags_to_move = listing.tag_list
+      first_tag_set, *remaining_tag_sets = splitter.split listing.tag_list
 
-      listing.tag_list = [first_tag]
-      listing.save!
+      listing.update! tag_list: [first_tag_set]
 
-      tags_to_move.map do |tag|
+      remaining_tag_sets.map do |tag_set|
         listing.dup.tap do |new_listing|
           new_listing.update!(
-            tag_list: [tag],
+            tag_list: tag_set,
             created_at: listing.created_at,
           )
         end
+      end
+    end
+  end
+
+  def splitter
+    @splitter ||= TagSplitter.new
+  end
+
+  class TagSplitter
+    attr_reader :lineages
+
+    def initialize lineages = nil
+      @lineages = lineages || gather_lineages
+    end
+
+    def gather_lineages
+      Category.all.map{ |category| [category.name, category.lineage] }.to_h
+    end
+
+    def split tag_list
+      matching_lineages = lineages
+        .values_at(*tag_list)
+        .sort_by{ |lineage| lineage.size }
+        .reverse
+
+      matching_lineages.reduce([]) do |minimal_set, lineage|
+        with_lineage = minimal_set + [lineage]
+        with_lineage.flatten.uniq.size > minimal_set.flatten.uniq.size ? with_lineage : minimal_set
       end
     end
   end

--- a/lib/tasks/support/listing_converter.rb
+++ b/lib/tasks/support/listing_converter.rb
@@ -1,0 +1,22 @@
+class ListingConverter
+  attr_reader :listing
+
+  def initialize listing
+    @listing = listing
+  end
+
+  def convert
+    Listing.transaction do
+      first_tag, *tags_to_move = listing.tag_list
+      tags_to_move.each do |tag|
+        new_listing = listing.dup
+        new_listing.update!(
+          tag_list: [tag],
+          created_at: listing.created_at,
+        )
+      end
+      listing.tag_list = [first_tag]
+      listing.save!
+    end
+  end
+end

--- a/lib/tasks/support/listing_converter.rb
+++ b/lib/tasks/support/listing_converter.rb
@@ -8,15 +8,18 @@ class ListingConverter
   def convert
     Listing.transaction do
       first_tag, *tags_to_move = listing.tag_list
-      tags_to_move.each do |tag|
-        new_listing = listing.dup
-        new_listing.update!(
-          tag_list: [tag],
-          created_at: listing.created_at,
-        )
-      end
+
       listing.tag_list = [first_tag]
       listing.save!
+
+      tags_to_move.map do |tag|
+        listing.dup.tap do |new_listing|
+          new_listing.update!(
+            tag_list: [tag],
+            created_at: listing.created_at,
+          )
+        end
+      end
     end
   end
 end

--- a/spec/lib/tasks/support/listing_converter_spec.rb
+++ b/spec/lib/tasks/support/listing_converter_spec.rb
@@ -3,50 +3,49 @@ require 'tasks/support/listing_converter'
 
 RSpec.describe ListingConverter do
   let(:converter) { ListingConverter.new listing }
+  let(:convert)   { converter.convert }
 
   describe 'does not process listing with one tag' do
     let!(:listing) { create :listing, tag_list: %w[errands] }
 
     it 'does not add any new listings' do
-      expect{ converter.convert }.to_not change(Listing, :count)
+      expect{ convert }.to_not change(Listing, :count)
     end
 
     it 'does not change the listing' do
-      converter.convert
+      convert
       expect(listing.changes).to be_empty
     end
   end
 
   context 'for a listing with multiple tags' do
-    let(:listing)     { create :listing, tag_list: %w[cash errands housing] }
-    let(:new_listing) { Listing.last }
+    let(:listing) { create :listing, tag_list: %w[cash errands housing] }
 
     it 'removes all but the first tag from the original listing' do
-      converter.convert
+      convert
       expect(listing.reload.tag_list).to eq %w[cash]
     end
 
     it 'creates a listing for each extraneous tag' do
-      converter.convert
+      convert
       expect(Listing.count).to be 3
     end
 
     it 'sets the tag on each new listings' do
-      converter.convert
-      expect(new_listing.tag_list).to eq %w[housing]
+      new_listings = convert
+      expect(new_listings.map(&:tag_list)).to contain_exactly %w[errands], %w[housing]
     end
 
     it 'copies attributes from original listing except id, tag_list, and updated_at' do
-      converter.convert
       original = listing.attributes.to_a
+      new_listing = convert.last
       copied = new_listing.attributes.to_a
       expect((copied - original).to_h.keys).to match_array %w[id tag_list updated_at]
     end
 
     it 'keeps the association with a submission' do
-      listing.submission = create(:submission)
-      listing.save!
-      converter.convert
+      listing.update!(submission: create(:submission))
+      new_listing = convert.last
       expect(new_listing.submission).to be_present
       expect(new_listing.submission).to eq listing.submission
     end
@@ -60,12 +59,14 @@ RSpec.describe ListingConverter do
       end
 
       it 'keeps matches only on the original listing' do
-        converter.convert
+        new_listing = convert.last
         expect(listing.matches_as_provider).to_not be_empty
         expect(listing.matches_as_receiver).to_not be_empty
         expect(new_listing.matches_as_provider).to be_empty
         expect(new_listing.matches_as_receiver).to be_empty
       end
     end
+
+    pending 'when tags include sub-categories'
   end
 end

--- a/spec/lib/tasks/support/listing_converter_spec.rb
+++ b/spec/lib/tasks/support/listing_converter_spec.rb
@@ -2,28 +2,20 @@ require 'rails_helper'
 require 'tasks/support/listing_converter'
 
 RSpec.describe ListingConverter do
-  let(:converter) { ListingConverter.new listing }
-  let(:convert)   { converter.convert }
+  let(:converter) { ListingConverter.new }
+  let(:convert)   { converter.convert listing }
 
-  describe 'does not process listing with one tag' do
-    let!(:listing) { create :listing, tag_list: %w[errands] }
+  before { Category.destroy_all } # from seeds
 
-    it 'does not add any new listings' do
-      expect{ convert }.to_not change(Listing, :count)
-    end
+  context 'without sub-categories' do
+    let(:tags)        { %w[cash errands housing] }
+    let!(:categories) { tags.map{ |name| create :category, name: name }}
+    let(:listing)     { create :listing, tag_list: tags }
 
-    it 'does not change the listing' do
+    it 'removes all but one tag from the original listing' do
       convert
-      expect(listing.changes).to be_empty
-    end
-  end
-
-  context 'for a listing with multiple tags' do
-    let(:listing) { create :listing, tag_list: %w[cash errands housing] }
-
-    it 'removes all but the first tag from the original listing' do
-      convert
-      expect(listing.reload.tag_list).to eq %w[cash]
+      expect(listing.reload.tag_list.size).to be 1
+      expect(tags).to include listing.tag_list.first
     end
 
     it 'creates a listing for each extraneous tag' do
@@ -31,9 +23,9 @@ RSpec.describe ListingConverter do
       expect(Listing.count).to be 3
     end
 
-    it 'sets the tag on each new listings' do
+    it 'sets the tag on each new listing' do
       new_listings = convert
-      expect(new_listings.map(&:tag_list)).to contain_exactly %w[errands], %w[housing]
+      expect(new_listings.map(&:tag_list).flatten).to match_array(tags - listing.reload.tag_list)
     end
 
     it 'copies attributes from original listing except id, tag_list, and updated_at' do
@@ -51,12 +43,8 @@ RSpec.describe ListingConverter do
     end
 
     describe 'with matches' do
-      let(:listing) do
-        listing = create(:listing, tag_list: %w[cash errands housing])
-        create(:match, :with_ask_and_offer, provider: listing)
-        create(:match, :with_ask_and_offer, receiver: listing)
-        listing
-      end
+      let!(:provider_match) { create(:match, :with_ask_and_offer, provider: listing) }
+      let!(:receiver_match) { create(:match, :with_ask_and_offer, receiver: listing) }
 
       it 'keeps matches only on the original listing' do
         new_listing = convert.last
@@ -66,7 +54,95 @@ RSpec.describe ListingConverter do
         expect(new_listing.matches_as_receiver).to be_empty
       end
     end
+  end
 
-    pending 'when tags include sub-categories'
+  context 'with only a parent- and sub-category' do
+    let!(:parent)      { create :category, name: 'food' }
+    let!(:child)       { create :category, name: 'meals', parent: parent }
+    let!(:listing)     { create :listing, tag_list: %w[food meals] }
+
+    it 'does not create any new listings' do
+      expect{ convert }.to_not change(Listing, :count)
+    end
+
+    it 'leaves the listing tags unchanged' do
+      convert
+      expect(listing.tag_list).to match_array %w[food meals]
+    end
+  end
+
+  context 'with a mix of single tags and and nested categories' do
+    let!(:unrelated)   { create :category, name: 'cash' }
+    let!(:parent)      { create :category, name: 'food' }
+    let!(:child)       { create :category, name: 'meals',     parent: parent }
+    let!(:other_child) { create :category, name: 'groceries', parent: parent }
+    let!(:grand_child) { create :category, name: 'delivery',  parent: child }
+
+    let!(:listing)     { create :listing, tag_list: %w[food meals cash groceries delivery] }
+
+    it 'leaves the listing with one of the tag sets' do
+      convert
+      expect(listing.tag_list).to match_array %w[food meals delivery]
+    end
+
+    it 'creates listing for the remaining tag sets' do
+      expect(convert.map(&:tag_list)).to match_array [
+        %w[cash],
+        %w[food groceries],
+      ]
+    end
+  end
+
+  describe 'TagSplitter' do
+    let(:splitter) { ListingConverter::TagSplitter.new(lineages) }
+    let(:lineages) {{
+      'grandchild'  => %w[parent child grandchild],
+      'child'       => %w[parent child],
+      'other_child' => %w[parent other_child],
+      'parent'      => %w[parent],
+      'orphan'      => %w[orphan],
+    }}
+
+    subject { splitter.split tag_list }
+
+    context 'single tag' do
+      let(:tag_list) { %w[orphan] }
+      it { is_expected.to contain_exactly %w[orphan] }
+    end
+
+    context 'unrelated tags' do
+      let(:tag_list) { %w[parent orphan] }
+      it { is_expected.to contain_exactly %w[parent], %w[orphan] }
+    end
+
+    context 'parent, child' do
+      let(:tag_list) { %w[parent child] }
+      it { is_expected.to contain_exactly %w[parent child] }
+    end
+
+    context 'when tagged out of order' do
+      let(:tag_list) { %w[child parent] }
+      it { is_expected.to contain_exactly %w[parent child] }
+    end
+
+    context 'parent, orphan, child' do
+      let(:tag_list) { %w[parent child orphan] }
+      it { is_expected.to contain_exactly %w[parent child], %w[orphan] }
+    end
+
+    context 'parent, child, other_child' do
+      let(:tag_list) { %w[parent child other_child] }
+      it { is_expected.to contain_exactly %w[parent child], %w[parent other_child] }
+    end
+
+    context 'parent, child, other_child, grandchild' do
+      let(:tag_list) { %w[parent child other_child grandchild] }
+      it { is_expected.to contain_exactly %w[parent child grandchild], %w[parent other_child] }
+    end
+
+    context 'parent, child, other_child, grandchild' do
+      let(:tag_list) { %w[parent child other_child grandchild] }
+      it { is_expected.to contain_exactly %w[parent child grandchild], %w[parent other_child] }
+    end
   end
 end

--- a/spec/lib/tasks/support/listing_converter_spec.rb
+++ b/spec/lib/tasks/support/listing_converter_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+require 'tasks/support/listing_converter'
+
+RSpec.describe ListingConverter do
+  let(:converter) { ListingConverter.new listing }
+
+  describe 'does not process listing with one tag' do
+    let!(:listing) { create :listing, tag_list: %w[errands] }
+
+    it 'does not add any new listings' do
+      expect{ converter.convert }.to_not change(Listing, :count)
+    end
+
+    it 'does not change the listing' do
+      converter.convert
+      expect(listing.changes).to be_empty
+    end
+  end
+
+  context 'for a listing with multiple tags' do
+    let(:listing)     { create :listing, tag_list: %w[cash errands housing] }
+    let(:new_listing) { Listing.last }
+
+    it 'removes all but the first tag from the original listing' do
+      converter.convert
+      expect(listing.reload.tag_list).to eq %w[cash]
+    end
+
+    it 'creates a listing for each extraneous tag' do
+      converter.convert
+      expect(Listing.count).to be 3
+    end
+
+    it 'sets the tag on each new listings' do
+      converter.convert
+      expect(new_listing.tag_list).to eq %w[housing]
+    end
+
+    it 'copies attributes from original listing except id, tag_list, and updated_at' do
+      converter.convert
+      original = listing.attributes.to_a
+      copied = new_listing.attributes.to_a
+      expect((copied - original).to_h.keys).to match_array %w[id tag_list updated_at]
+    end
+
+    it 'keeps the association with a submission' do
+      listing.submission = create(:submission)
+      listing.save!
+      converter.convert
+      expect(new_listing.submission).to be_present
+      expect(new_listing.submission).to eq listing.submission
+    end
+
+    describe 'with matches' do
+      let(:listing) do
+        listing = create(:listing, tag_list: %w[cash errands housing])
+        create(:match, :with_ask_and_offer, provider: listing)
+        create(:match, :with_ask_and_offer, receiver: listing)
+        listing
+      end
+
+      it 'keeps matches only on the original listing' do
+        converter.convert
+        expect(listing.matches_as_provider).to_not be_empty
+        expect(listing.matches_as_receiver).to_not be_empty
+        expect(new_listing.matches_as_provider).to be_empty
+        expect(new_listing.matches_as_receiver).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
This got complicated when we started to consider sub-categories!

See af063eca12d82ded8a2568d1c61a54320b7b60e2 for my attempt to deal with them. I'm not sure how well the code speaks for itself; happy to get on a call if that would be easier/better.

The `one_time:split_listings` rake task _should_ be idempotent on repeated runs, though it will always have to pull and examine any listings with sub-categories (since the query looks for any listing with multiple tags). I formatted the `puts` output to be csv compatible with 3 columns:
1. an indicator for visual scanning (`#` - listing being processed, `-` listing after processing, `+` newly created listings),
1. the listing id (original or new),
1. tag_list

Will definitely need some 👀 to verify my specs/logic and do some more testing.