### PR TITLE
Switch to `main` branch!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [Unreleased]
+### Development notes
+* Switched primary branch from `master` to `main` #658
 
 ## [0.2.9] - 2020-08-06
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you have any question of us source code maintainers, please feel free to reac
 
 # Contributing
 
-Visit our [CONTRIBUTING.md](https://github.com/rubyforgood/mutual-aid-app/blob/master/CONTRIBUTING.md) file for more information on making your contribution. We look forward to it!
+Visit our [CONTRIBUTING.md](CONTRIBUTING.md) file for more information on making your contribution. We look forward to it!
 
 
 # Setting Up Development


### PR DESCRIPTION
Not sure if there's actually anything more to change in code.
* Didn't find any reference to `master` in our CircleCI config (~we'll see how this PR does~ all good!).
* No mention of it in our deployment docs either, but i'm not sure if that's definitive?

There's probably more to do on GitHub itself but i don't have privileges to see those settings, @maebeale ?

Also went through and changed the base branch of all existing open PRs.

For developers, this change should be pretty simple to absorb:
* `git fetch && git switch main`.
* Rebase any local branches onto `main`.
* Or merge into/from `main`.