### PR TITLE
Fix docker buildfile

### DIFF
--- a/docker/development/app/Dockerfile
+++ b/docker/development/app/Dockerfile
@@ -1,10 +1,9 @@
-ARG APP_PORT
-
 FROM ruby:2.7.0-alpine
+
+ARG APP_PORT=3000
 
 RUN bundle config --global frozen 1
 WORKDIR /usr/src/app
-
 
 RUN apk add --update-cache postgresql-dev zlib build-base tzdata nodejs yarn
 
@@ -27,5 +26,6 @@ RUN yarn install
 COPY . ./
 
 EXPOSE ${APP_PORT}
+ENV PORT ${APP_PORT}
 
-CMD ["bundle", "exec", "rails", "server", "-p", "${APP_PORT}", "-b", "0.0.0.0"]
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]


### PR DESCRIPTION
Was resulting in an error when attempting to run the build:
  app_1    | /usr/local/bundle/gems/thor-1.0.1/lib/thor/parser/arguments.rb:133:in `parse_numeric': Expected numeric value for '--port'; got "${APP_PORT}" (Thor::MalformattedArgumentError)

There are two things that aren't quite set up right here:

The build arg was not in scope -- used args need to be _below_ the
`FROM` statement to be accessible.

CMD appears to not allow variable expansion, because it is processed at
runtime rather than build time.  Instead, we can export the `PORT`
envar, which will be picked up by `config/puma.rb` when starting rails.