### PR TITLE
[WIP] Add 'mad-libs' filtering to Contributions page

### DIFF
--- a/app/javascript/pages/Browse.vue
+++ b/app/javascript/pages/Browse.vue
@@ -7,6 +7,51 @@
       </p>
     </div>
 
+    <div class="madlibs">
+      <p>
+        <span class="madlibs-inline">I am </span>
+        <b-select v-model="contributionTypeFilter">
+          <option
+            v-for="[id, option] in Object.entries(contributionTypes)"
+            :value="id"
+            :key="id"
+          >
+            {{ option }}
+          </option>
+        </b-select>
+        <span class="madlibs-inline"> with </span>
+        <b-select v-model="contributionCategoryFilter">
+          <option
+            v-for="[id, category] in Object.entries(contributionCategories)"
+            :value="id"
+            :key="id"
+          >
+            {{ category }}
+          </option>
+        </b-select>
+        <span class="madlibs-inline">. I live near </span>
+        <b-select v-model="contributionServiceAreaFilter">
+          <option
+            v-for="[id, serviceArea] in Object.entries(contributionServiceAreas)"
+            :value="id"
+            :key="id"
+          >
+            {{ serviceArea }}
+          </option>
+        </b-select>
+        <span class="madlibs-inline">and I need help</span>
+        <b-select v-model="contributionTimeFrameFilter">
+          <option
+            v-for="[id, timeFrame] in Object.entries(contributionTimeFrames)"
+            :value="id"
+            :key="id"
+          >
+            {{ timeFrame }}
+          </option>
+        </b-select>
+      </p>
+    </div>
+
     <section class="section columns">
       <section class="column is-one-quarter">
         <BrowserSelector :browser="browser" @clicked="browser = $event" />
@@ -55,6 +100,14 @@ export default {
       browser: TileBrowser,
       activeFilters: this.initialFilters,
       activeContributions: this.contributions,
+      contributionCategories: {},
+      contributionCategoryFilter: 'any',
+      contributionServiceAreas: {},
+      contributionServiceAreaFilter: 'anywhere',
+      contributionTimeFrames: {},
+      contributionTimeFrameFilter: 0,
+      contributionTypeFilter: 'any',
+      contributionTypes: this.fetcher.types()
     }
   },
   watch: {
@@ -70,9 +123,45 @@ export default {
         if (result.error) this.flashIfError(result.error)
       })
     },
+    updateContributionFilters(contributions) {
+      let categories = { any: 'any category' }
+      let serviceAreas = { anywhere: '(anywhere)' }
+      let urgencies = {}
+      contributions.forEach(contribution => {
+        serviceAreas[contribution.service_area.id] = contribution.service_area.name
+        urgencies[contribution.urgency.id] = contribution.urgency.name
+        contribution.category_tags.forEach(tag => {
+          categories[tag.id] = tag.name
+        })
+      })
+      this.contributionCategories = categories
+      this.contributionServiceAreas = serviceAreas
+      this.contributionTimeFrames = urgencies
+      // this.contributionCategories = [{0: 'any category'}, ...new Set(this.activeContributions.map(contribution => contribution.category_tags).flat(1))]
+    },
     flashIfError(e) {
       console.log(e)
     },
   },
+  created: function() {
+    this.updateContributionFilters(this.activeContributions)
+  },
 }
 </script>
+
+<style scoped>
+.madlibs {
+  padding-top: 1em;
+  font-size: 18pt;
+}
+
+.madlibs-inline {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.control {
+  display: inline-block;
+  vertical-align: middle;
+}
+</style>

--- a/app/javascript/pages/browse/ContributionFetcher.js
+++ b/app/javascript/pages/browse/ContributionFetcher.js
@@ -1,25 +1,33 @@
 export default class {
-  constructor(path = '/listing.json?', injectedFetch) {
-    !!injectedFetch
-      ? (this.injectedFetch = injectedFetch)
-      : (this.injectedFetch = this.defaultFetch())
-    this.path = path
-  }
-  fetch(filters, fallback = []) {
-    return this.injectedFetch(this.path + this.parsedFilters(filters))
-      .then((response) => response.json())
-      .then((jsonData) => {
-        return {data: jsonData}
-      })
-      .catch((error) => ({error: error, data: fallback}))
-  }
-  parsedFilters(filters = []) {
-    return filters.map((filter) => '' + filter + '=1').join('&')
-  }
-  defaultFetch() {
-    return typeof window === 'undefined' ? this.noopFetch : (args) => window.fetch(args)
-  }
-  async noopFetch() {
-    return
-  }
+    constructor(path = '/listing.json?', injectedFetch) {
+        !!injectedFetch
+            ?
+            (this.injectedFetch = injectedFetch) :
+            (this.injectedFetch = this.defaultFetch())
+        this.path = path
+    }
+    fetch(filters, fallback = []) {
+        return this.injectedFetch(this.path + this.parsedFilters(filters))
+            .then((response) => response.json())
+            .then((jsonData) => {
+                return { data: jsonData }
+            })
+            .catch((error) => ({ error: error, data: fallback }))
+    }
+    parsedFilters(filters = []) {
+        return filters.map((filter) => '' + filter + '=1').join('&')
+    }
+    types() {
+        return {
+            any: "browsing asks and offers",
+            asks: "looking for help",
+            offers: "can offer help"
+        }
+    }
+    defaultFetch() {
+        return typeof window === 'undefined' ? this.noopFetch : (args) => window.fetch(args)
+    }
+    async noopFetch() {
+        return
+    }
 }


### PR DESCRIPTION
Changes to the ContributionFetcher library to add a hardcoded list of contribution types and changes to the Browse.vue SFC to display filters in a madlibs style form.

Still needs:
- [ ] update the active filters based on selections in the dropdowns
- [ ] update page text about filters to include the mad-libs option
- [ ] maybe some backend stuff for the different filter options instead of calculating them from the contributions data

https://github.com/rubyforgood/mutual-aid/issues/641