### PR TITLE
Option to display navbar

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -3,7 +3,7 @@ class AnnouncementsController < ApplicationController
   before_action :authenticate_user!, except: [:new, :create]
   before_action :set_announcement, only: [:show, :edit, :update, :destroy]
 
-  layout "without_navbar", only: [:new, :create, :show]
+  layout :determine_layout
 
   def index
     @announcements = Announcement.order(created_at: :desc)
@@ -45,6 +45,10 @@ class AnnouncementsController < ApplicationController
   private
     def set_announcement
       @announcement = Announcement.find(params[:id])
+    end
+
+    def determine_layout
+      "without_navbar" unless @system_setting.display_navbar
     end
 
     def announcement_params

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -3,7 +3,7 @@ class AnnouncementsController < ApplicationController
   before_action :authenticate_user!, except: [:new, :create]
   before_action :set_announcement, only: [:show, :edit, :update, :destroy]
 
-  layout :determine_layout
+  layout :determine_layout, only: [:new, :create, :show]
 
   def index
     @announcements = Announcement.order(created_at: :desc)

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -3,7 +3,7 @@ class AnnouncementsController < ApplicationController
   before_action :authenticate_user!, except: [:new, :create]
   before_action :set_announcement, only: [:show, :edit, :update, :destroy]
 
-  layout :determine_layout, only: [:new, :create, :show]
+  layout :determine_layout, only: [:new, :show]
 
   def index
     @announcements = Announcement.order(created_at: :desc)
@@ -48,7 +48,7 @@ class AnnouncementsController < ApplicationController
     end
 
     def determine_layout
-      "without_navbar" unless @system_setting.display_navbar
+      "without_navbar" unless @system_setting.display_navbar?
     end
 
     def announcement_params

--- a/app/controllers/community_resources_controller.rb
+++ b/app/controllers/community_resources_controller.rb
@@ -3,8 +3,7 @@ class CommunityResourcesController < ApplicationController
   before_action :authenticate_user!, except: [:new, :create]
   before_action :set_community_resource, only: [:show, :edit, :update, :destroy]
 
-  layout :determine_layout
-  # layout "without_navbar", only: [:new, :create, :show]
+  layout :determine_layout, only: [:new, :create, :show]
 
   def index
     @community_resources = CommunityResource.includes(:organization).references(:organization).order(created_at: :desc)

--- a/app/controllers/community_resources_controller.rb
+++ b/app/controllers/community_resources_controller.rb
@@ -3,7 +3,8 @@ class CommunityResourcesController < ApplicationController
   before_action :authenticate_user!, except: [:new, :create]
   before_action :set_community_resource, only: [:show, :edit, :update, :destroy]
 
-  layout "without_navbar", only: [:new, :create, :show]
+  layout :determine_layout
+  # layout "without_navbar", only: [:new, :create, :show]
 
   def index
     @community_resources = CommunityResource.includes(:organization).references(:organization).order(created_at: :desc)
@@ -54,6 +55,10 @@ class CommunityResourcesController < ApplicationController
 
     def set_form_dropdowns
       @available_tags = Category.visible.pluck(:name) + @community_resource&.tag_list || []
+    end
+
+    def determine_layout
+      "without_navbar" unless @system_setting.display_navbar
     end
 
     def community_resource_params

--- a/app/controllers/community_resources_controller.rb
+++ b/app/controllers/community_resources_controller.rb
@@ -3,7 +3,7 @@ class CommunityResourcesController < ApplicationController
   before_action :authenticate_user!, except: [:new, :create]
   before_action :set_community_resource, only: [:show, :edit, :update, :destroy]
 
-  layout :determine_layout, only: [:new, :create, :show]
+  layout :determine_layout, only: [:new, :show]
 
   def index
     @community_resources = CommunityResource.includes(:organization).references(:organization).order(created_at: :desc)
@@ -57,7 +57,7 @@ class CommunityResourcesController < ApplicationController
     end
 
     def determine_layout
-      "without_navbar" unless @system_setting.display_navbar
+      "without_navbar" unless @system_setting.display_navbar?
     end
 
     def community_resource_params

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -1,8 +1,12 @@
 class PublicPagesController < PublicController
-  layout "without_navbar", only: [:announcements, :community_resources]
+  layout :determine_layout
 
   def about
     @about_us_text = HtmlSanitizer.new(@system_setting.about_us_text).sanitize_for_rails
+  end
+
+  def determine_layout
+    "without_navbar" unless @system_setting.display_navbar
   end
 
   def announcements

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -6,7 +6,7 @@ class PublicPagesController < PublicController
   end
 
   def determine_layout
-    "without_navbar" unless @system_setting.display_navbar
+    "without_navbar" unless @system_setting.display_navbar?
   end
 
   def announcements

--- a/app/controllers/system_settings_controller.rb
+++ b/app/controllers/system_settings_controller.rb
@@ -55,6 +55,7 @@ class SystemSettingsController < ApplicationController
         :allow_sms,
         :exchange_type,
         :separate_asks_offers,
+        :display_navbar,
 
         :announcements_module,
         :community_resources_module,

--- a/app/views/system_settings/_form.html.erb
+++ b/app/views/system_settings/_form.html.erb
@@ -5,6 +5,7 @@
     <%= f.input :exchange_type, as: :select, collection: @exchange_types %>
     <%= f.input :separate_asks_offers, as: :radio_buttons, label: "Separate ask and offer forms" %>
     <%= f.input :allow_sms, as: :radio_buttons %>
+    <%= f.input :display_navbar, as: :radio_buttons, hint: "Display the navbar on the Community Resources and Annoucements pages" %>
     <%= f.input :community_resources_module, as: :radio_buttons %>
     <%= f.input :announcements_module, as: :radio_buttons %>
     <%= f.input :positions_module, as: :radio_buttons %>

--- a/app/views/system_settings/show.html.erb
+++ b/app/views/system_settings/show.html.erb
@@ -14,6 +14,10 @@
     <strong>Separate ask and offer forms</strong>
   </p>
 
+  <p>
+    <%= yes_no(@system_setting.display_navbar) %>
+    <strong>Display the navbar</strong> on the Community Resources and Annoucements pages
+  </p>
 
   <hr>
   <div class="subtitle is-5">Modules</div>

--- a/db/migrate/20200906172102_add_display_navbar_to_system_settings.rb
+++ b/db/migrate/20200906172102_add_display_navbar_to_system_settings.rb
@@ -1,0 +1,5 @@
+class AddDisplayNavbarToSystemSettings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :system_settings, :display_navbar, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_25_153314) do
+ActiveRecord::Schema.define(version: 2020_09_06_172102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -445,6 +445,7 @@ ActiveRecord::Schema.define(version: 2020_06_25_153314) do
     t.string "confirmation_page_text_body"
     t.string "confirmation_page_text_link_header"
     t.string "confirmation_page_text_footer"
+    t.boolean "display_navbar", default: false
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,7 @@
 User.where(email: "#{ENV["SYSTEM_EMAIL"]}").first_or_create!(
   password: "#{ENV["SYSTEM_PASSWORD"]}",
   confirmed_at: Time.current,
+  role: "sys_admin"
 )
 
 # create categories -- these are then editable by admin users


### PR DESCRIPTION
The issue is attached - there needs to be an option as to whether the navbar should show up on the Community Resources and the Annoucements pages. So I added an option for that in system settings that can be toggled. 

Question: 
the lists /annoucements-list and /community-resources-list are both handled by PublicPagesController, so I added the same method in there as well but I am not sure if that was intended or not (last commit)

Also should index also have the display_navbar switch or should it always be without_navbar? 