### PR TITLE
Only start development services by default via make

### DIFF
--- a/docker/development/Makefile
+++ b/docker/development/Makefile
@@ -19,7 +19,7 @@ seed_test:
 	docker-compose run app bin/rake db:seed RAILS_ENV=test
 
 start:
-	docker-compose up
+	docker-compose up app
 
 startd:
 	docker-compose up -d


### PR DESCRIPTION
There's no need to run the test service when booting the application
for development via docker and Make