### PR TITLE
Cleanup one-off development containers created via make

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -184,7 +184,7 @@ To get started using the application with docker,
 4. From within the repository, navigate to the `/docker/development` folder. If you are in the right folder, you will see a file named `docker-compose.yml` and a file named `Makefile`.
 5. Now you should be able to run `make start`. This will start the application in daemon mode, which means that the server will keep running in the background. If you navigate to  `localhost:3000` in your browser, you will see an error. This is normal, and it means that you still need to setup the database.
 6. To setup the database, you can run
-  `EMAIL=${SYSTEM_EMAIL} PASSWORD=${SYSTEM_PASSWORD} make seed`
+  `SYSTEM_EMAIL=${SYSTEM_EMAIL} SYSTEM_PASSWORD=${SYSTEM_PASSWORD} make seed`
   This will setup the database and create a default admin user with the email and password as specified by the `SYSTEM_EMAIL` and `SYSTEM_PASSWORD` environment variables which are ultimately passed to `docker-compose` with the `-e` option. If you don't want to create the default user, you can just run `make prepare` and create the account using the sign up option on the website.
 
 7. You should now be able to reload `localhost:3000` in your browser. If everything went well, the website should appear and be functional. You can sign in using the email and password you set in the previous step. This docker compose also setups an a `mailcatcher` server, which you can access at `localhost:1080`. All emails will be delivered to mailcatcher, which should allow you to setup user accounts.

--- a/docker/development/Makefile
+++ b/docker/development/Makefile
@@ -7,16 +7,16 @@ logs:
 	docker-compose logs
 
 rspec:
-	docker-compose run app bin/rspec
+	docker-compose run --rm app bin/rspec
 
 prepare:
-	docker-compose run app db:prepare
+	docker-compose run --rm app db:prepare
 
 seed:
-	docker-compose run -e SYSTEM_EMAIL=${EMAIL}  -e SYSTEM_PASSWORD=${PASSWORD} app rails db:prepare db:seed
+	docker-compose run --rm -e SYSTEM_EMAIL=${SYSTEM_EMAIL}  -e SYSTEM_PASSWORD=${SYSTEM_PASSWORD} app rails db:prepare db:seed
 
 seed_test:
-	docker-compose run app bin/rake db:seed RAILS_ENV=test
+	docker-compose run --rm app bin/rake db:seed RAILS_ENV=test
 
 start:
 	docker-compose up app
@@ -28,10 +28,10 @@ stop:
 	docker-compose down
 
 test:
-	docker-compose run app bin/test
+	docker-compose run --rm app bin/test
 
 webpack:
-	docker-compose run app bin/webpack-dev-server
+	docker-compose run --rm app bin/webpack-dev-server
 
 wipe:
 	docker-compose down --volumes --remove-orphans


### PR DESCRIPTION
Before, any one-off container made by these make tasks hangs around in
an exited state after command execution is terminated - notice
`development_app_run_e3b196b37f5d` in the example below:

```
[maximilian: development] cleanup-one-off-development-containers *^ →
$ make rspec
docker-compose run app bin/rspec

...snip...

Finished in 36.48 seconds (files took 11.52 seconds to load)
286 examples, 0 failures, 177 pending

Randomized with seed 34516

[maximilian: development] cleanup-one-off-development-containers *^ →
$ docker-compose ps -a
              Name                            Command               State                 Ports
-------------------------------------------------------------------------------------------------------------
development_app_run_e3b196b37f5d   bin/rspec                        Exit 0
development_db_1                   docker-entrypoint.sh postgres    Up       5432/tcp
development_email_1                mailcatcher --foreground - ...   Up       1025/tcp, 0.0.0.0:1080->1080/tcp
```

After, one off containers delete themselves when the container
exits. Notice in the example below that the
`development_app_run_<container-id>` container is not present after execution:

```
[maximilian: development] cleanup-one-off-development-containers +^ →
$ make rspec
docker-compose run --rm app bin/rspec

...snip...

Finished in 38.43 seconds (files took 11.91 seconds to load)
286 examples, 0 failures, 177 pending

Randomized with seed 10269

[maximilian: development] cleanup-one-off-development-containers +^ →
$ docker-compose ps -a
       Name                      Command               State                Ports
-----------------------------------------------------------------------------------------------
development_db_1      docker-entrypoint.sh postgres    Up      5432/tcp
development_email_1   mailcatcher --foreground - ...   Up      1025/tcp, 0.0.0.0:1080->1080/tcp
```

Nice and tidy.