### PR TITLE
Upgrade puma, mostly to simplify dev setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'faker' # need this in prod for demo seeds to work
 gem 'jbuilder', '~> 2.7'
 gem 'mobility', '~> 0.8.9'
 gem 'pg', '>= 0.18', '< 2.0'
-gem 'puma', '~> 4.3'
+gem 'puma', '~> 5.0'
 gem 'rack-timeout'
 gem 'reform-rails'
 gem 'sendgrid-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    puma (4.3.5)
+    puma (5.0.0)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-proxy (0.6.5)
@@ -303,7 +303,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry
   pry-byebug
-  puma (~> 4.3)
+  puma (~> 5.0)
   rack-timeout
   rails (~> 6.0.2, >= 6.0.2.2)
   reform-rails


### PR DESCRIPTION
Newer version of puma is easier to build on a fresh box.