### PR TITLE
Fix environment mismatch error in docker env tests

### DIFF
--- a/bin/dev/bootstrap
+++ b/bin/dev/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/dev/bootstrap
+++ b/bin/dev/bootstrap
@@ -2,7 +2,15 @@
 
 set -e
 
-bin/dev/clean
+function setup() {
+    local environment
+    environment="$1"
 
-docker-compose -f docker/development/docker-compose.yml run --rm \
-               app rails db:prepare db:seed
+    docker-compose -f docker/development/docker-compose.yml \
+                   run --rm \
+                   app bin/rails db:reset RAILS_ENV="${environment}"
+}
+
+bin/dev/clean
+setup development
+setup test

--- a/bin/dev/clean
+++ b/bin/dev/clean
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Remove all containers, volumes, images, etc associated with this project's services.
 docker-compose -f ./docker/development/docker-compose.yml down --rmi=all --volumes --remove-orphans

--- a/bin/dev/console
+++ b/bin/dev/console
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker-compose -f ./docker/development/docker-compose.yml run --rm app bin/rails console

--- a/bin/dev/serve
+++ b/bin/dev/serve
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 services="${*:-email webpacker app}"
 

--- a/bin/dev/shell
+++ b/bin/dev/shell
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker-compose -f ./docker/development/docker-compose.yml run --rm app /bin/sh

--- a/bin/dev/stop
+++ b/bin/dev/stop
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker-compose -f ./docker/development/docker-compose.yml down

--- a/bin/dev/test
+++ b/bin/dev/test
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker-compose -f ./docker/development/docker-compose.yml run --rm app bin/test

--- a/config/database.yml
+++ b/config/database.yml
@@ -27,30 +27,30 @@
 default: &default
   adapter:  postgresql
   encoding: unicode
-  username: <%= ENV.fetch('POSTGRES_USER',     nil) %>
-  password: <%= ENV.fetch('POSTGRES_PASSWORD', nil) %>
-  database: <%= ENV.fetch('POSTGRES_DB',       nil) %>
+  username: <%= ENV['POSTGRES_USER'].presence || nil %>
+  password: <%= ENV['POSTGRES_PASSWORD'].presence || nil %>
+  database: <%= ENV['POSTGRES_DB'].presence || nil %>
   # https://til.hashrocket.com/posts/6918d4e62b-use-postgresql-socket-in-databaseyml
-  host:     <%= ENV.fetch('POSTGRES_HOST',     '/var/run/postgres') %>
+  host:     <%= ENV['POSTGRES_HOST'].presence || '/var/run/postgres' %>
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool:     <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
+  pool:     <%= ENV["RAILS_MAX_THREADS"].presence || 5 %>
 
 development:
   <<: *default
-  database: <%= ENV.fetch('POSTGRES_DB', 'mutualaid_development') %>
+  database: <%= ENV['POSTGRES_DB'].presence || 'mutualaid_development' %>
 
 docker-development:
   <<: *default
-  database: <%= ENV.fetch('POSTGRES_DB', 'mutualaid_development') %>
+  database: <%= ENV['POSTGRES_DB'].presence || 'mutualaid_development' %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: <%= ENV.fetch('POSTGRES_DB', 'mutualaid_test') %>
+  database: <%= ENV['POSTGRES_DB'].presence || 'mutualaid_test' %>
 
 production:
   <<: *default
-  database: <%= ENV.fetch('POSTGRES_DB', 'mutualaid_production') %>
-  username: <%= ENV.fetch('POSTGRES_USER', 'mutualaid') %>
+  database: <%= ENV['POSTGRES_DB'].presence || 'mutualaid_production' %>
+  username: <%= ENV['POSTGRES_USER'].presence || 'mutualaid' %>

--- a/docker/development/app/Dockerfile
+++ b/docker/development/app/Dockerfile
@@ -11,6 +11,7 @@ ENV RAILS_ENV='' \
     POSTGRES_HOST='' \
     POSTGRES_PASSWORD='' \
     POSTGRES_USER='postgres' \
+    POSTGRES_DB='' \
     EMAIL_PORT='' \
     EMAIL_HOST='' \
     EMAIL_FROM_ADDR='' \

--- a/docker/development/app/Dockerfile
+++ b/docker/development/app/Dockerfile
@@ -11,7 +11,6 @@ ENV RAILS_ENV='' \
     POSTGRES_HOST='' \
     POSTGRES_PASSWORD='' \
     POSTGRES_USER='postgres' \
-    POSTGRES_DB='' \
     EMAIL_PORT='' \
     EMAIL_HOST='' \
     EMAIL_FROM_ADDR='' \

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -1,5 +1,6 @@
 version: "3.4"
 x-shared-postgres-environment: &x-shared-postgres-environment
+  POSTGRES_DB: "${POSTGRES_DB}"
   POSTGRES_USER: "${POSTGRES_USER:-postgres}"
   # this variable should be set in a .env file or passed via the docker-compose cli
   POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -1,6 +1,5 @@
 version: "3.4"
 x-shared-postgres-environment: &x-shared-postgres-environment
-  POSTGRES_DB: "${POSTGRES_DB:-mutualaid}"
   POSTGRES_USER: "${POSTGRES_USER:-postgres}"
   # this variable should be set in a .env file or passed via the docker-compose cli
   POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"


### PR DESCRIPTION
Fixes `ActiveRecord::EnvironmentMismatchError` after a
`bin/dev/bootstrap` and `bin/dev/test`.

TLDR; The `development` and `test` environments were sharing the
`mutualaid` database instead of being isolated in their own databases.

References
----------

- #718