### PR TITLE
Silence Ruby 2.7.0 deprecation warnings

### DIFF
--- a/.env
+++ b/.env
@@ -25,3 +25,13 @@ HOURS_PASSWORD_RESET_LINK_EXPIRES_AFTER=8
 # with `public_repo` access and set it in .env.local (NOT HERE)
 # https://github.com/release-it/release-it/blob/master/docs/github-releases.md
 GITHUB_TOKEN=not-a-real-token
+
+# TODO: DELETE ME - This is intended temporarily silence deprecation
+# warnings emitted from third-party gems that have yet to become
+# compatible with Ruby 2.7.0.  This is somewhat dangerous if left in
+# long-term as warnings use of soon-to-be-removed language features by
+# the application itself will be silenced.
+#
+# This should be removed before the next time this code base upgrades
+# Ruby.
+RUBYOPT=-W:no-deprecated

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -6,6 +6,7 @@ x-shared-postgres-environment: &x-shared-postgres-environment
   POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
 
 x-shared-environment-defaults:
+  - &RUBYOPT "${RUBYOPT}"
   - &APP_PORT "${APP_PORT:-3000}"
   - &EMAIL_PORT "${EMAIL_PORT:-1080}"
   - &WEBPACKER_DEV_SERVER_PORT "${WEBPACKER_DEV_SERVER_PORT:-3035}"
@@ -57,6 +58,7 @@ services:
       POSTGRES_HOST: db
       WEBPACKER_DEV_SERVER_HOST: webpacker
       WEBPACKER_DEV_SERVER_PORT: *WEBPACKER_DEV_SERVER_PORT
+      RUBYOPT: *RUBYOPT
 
   webpacker:
     build:


### PR DESCRIPTION
This is intended temporarily silence deprecation warnings emitted from
third-party gems that have yet to become compatible with Ruby 2.7.0.
This is somewhat dangerous if left in long-term as warnings use of
soon-to-be-removed language features by the application itself will be
silenced.

This should be removed before the next time this code base upgrades
Ruby.

**NOTE**

This does NOT silence Rails deprecation warnings, these
should probably be addressed independently - a quick eyeball survey
shows that most of the Rails deprecation warnings are addressable in
the application code.

References
----------

- https://github.com/rubyforgood/mutual-aid/issues/718