### PR TITLE
Cleanup contributions view

### DIFF
--- a/app/assets/stylesheets/bulma_and_buefy.scss
+++ b/app/assets/stylesheets/bulma_and_buefy.scss
@@ -1,8 +1,17 @@
 // Import Bulma's core if needed for customizations
-// @import "bulma/sass/utilities/_all";
+@import "bulma/sass/utilities/_all";
+@import "bulma/sass/components/navbar";
 
 // Our customizations
 $input-placeholder-color: hsl(0, 0%, 86%); //has-text-grey-lighter
+
+.subnav {
+  .navbar-item {
+    &.is-active {
+      color: $navbar-item-hover-color;
+    }
+  }
+}
 
 
 @import "bulma/bulma";

--- a/app/javascript/components/MappedIconList.vue
+++ b/app/javascript/components/MappedIconList.vue
@@ -1,6 +1,6 @@
 <template>
   <ul>
-    <li v-for="icon in iconData" :key="icon.name" class="tag">
+    <li v-for="icon in iconData" :key="icon.name" class="tag ml-1">
       <b-icon :icon="icon.image" :aria-label="icon.name"/>
     </li>
   </ul>

--- a/app/javascript/pages/browse/BrowserSelector.vue
+++ b/app/javascript/pages/browse/BrowserSelector.vue
@@ -1,15 +1,20 @@
 <template>
-  <div class="buttons has-addons">
-    <button :disabled="showingTiles" @click="showTiles" id="show-tiles" class="button is-small">
-      Tile view
-    </button>
-    <button :disabled="showingList"  @click="showList"  id="show-list"  class="button is-small">
-      List view
-    </button>
-    <button :disabled="showingMap"  @click="showMap"  id="show-map"  class="button is-small">
-      Map view
-    </button>
-  </div>
+  <b-navbar aria-label="contributions navigation" class="mb-3 subnav">
+    <template slot="start">
+      <b-navbar-item :active="showingTiles" @click="showTiles" id="show-tiles">
+        <b-icon icon="th-large"></b-icon>
+        <div class="ml-1">Tile View</div>
+      </b-navbar-item>
+      <b-navbar-item :active="showingList" @click="showList"  id="show-list">
+          <b-icon icon="th-list"></b-icon>
+          <div class="ml-1">List View</div>
+      </b-navbar-item>
+      <b-navbar-item :active="showingMap" @click="showMap"  id="show-map">
+          <b-icon icon="map-marked-alt"></b-icon>
+          <div class="ml-1">Map View</div>
+      </b-navbar-item>
+    </template>
+  </b-navbar>
 </template>
 
 <script>

--- a/app/javascript/pages/browse/ListBrowser.vue
+++ b/app/javascript/pages/browse/ListBrowser.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="listBrowser">
-    <table class="table table-hover table-curved table-condensed is-hoverable">
+    <table class="table table-hover table-curved table-condensed is-hoverable is-fullwidth">
       <tr>
         <th>Type</th>
         <th>Categories</th>

--- a/app/javascript/pages/browse/TileListItem.vue
+++ b/app/javascript/pages/browse/TileListItem.vue
@@ -1,44 +1,46 @@
 <template>
-  <li class="tileListItem box is-paddingless">
-    <div class="header">
-      <div class="tags">
-        <div class="right-tags tags">
-          <div class="left-tags">
-            <TagList :tags="category_tags" class="categoryTags" tagClasses="tag is-info is-light subtitle is-5" />
-          </div>
+  <div class="tileListItem is-marginless is-paddingless">
+    <div class="box ml-1 mr-1 mb-1 mt-1">
+      <div class="header">
+        <div class="row left">
+          <SingleIcon :iconType="contribution_type" klass="" />
+          <MappedIconList :iconTypes="iconList" />
         </div>
-      </div>
-    </div>
-
-    <div class="body">
-      <div class="row left">
-        <SingleIcon :iconType="contribution_type" klass="" />
-        <MappedIconList :iconTypes="iconList" />
-        <span class="has-text-right">
+        <div class="row right">
           <b-tag v-if="urgency" :class="urgencyColor">
             <b-icon v-if="showUrgentIcon" icon="exclamation-triangle" size="is-small" />
             {{ urgency.name }}
           </b-tag>
-        </span>
+        </div>
       </div>
 
-      <div class="text">
-        <div>
-          <small><time :datetime="createdAtDate.toISOString()">{{ createdAtDate.toLocaleDateString() }} {{ createdAtDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) }}</time></small>
+      <div class="body">
+        <div class="tags">
+          <div class="right-tags tags">
+            <div class="left-tags">
+              <TagList :tags="category_tags" class="categoryTags" tagClasses="tag is-info is-light subtitle" />
+            </div>
+          </div>
         </div>
-        <h5 class="has-text-weight-bold">{{ title }}</h5>
-        <p>{{ description }}</p>
-        <div v-if="service_area" class="has-text-grey-lighter">
-          {{ service_area.name }}
+
+        <div class="text">
+          <div>
+            <small><time :datetime="createdAtDate.toISOString()">{{ createdAtDate.toLocaleDateString() }} {{ createdAtDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) }}</time></small>
+          </div>
+          <h5 class="has-text-weight-bold">{{ title }}</h5>
+          <p>{{ description }}</p>
+          <div v-if="service_area" class="has-text-grey-lighter">
+            {{ service_area.name }}
+          </div>
+        </div>
+      </div>
+      <div class="actions">
+        <div class="buttonSpacing" v-if="respond_path">
+          <a :href="respond_path" class="button icon-list is-primary"><span class=""> Respond</span></a>
         </div>
       </div>
     </div>
-    <div class="actions">
-      <div class="buttonSpacing" v-if="respond_path">
-        <a :href="respond_path" class="button icon-list is-primary"><span class=""> Respond</span></a>
-      </div>
-    </div>
-  </li>
+  </div>
 </template>
 
 <script>

--- a/spec/javascript/pages/Browse.spec.js
+++ b/spec/javascript/pages/Browse.spec.js
@@ -8,8 +8,8 @@ describe('Browse', () => {
   def('wrapper', () => mount(Browse))
 
   describe('browser view', () => {
-    def('showTilesButton', () => $wrapper.find('button#show-tiles'))
-    def('showListButton', () => $wrapper.find('button#show-list'))
+    def('showTilesButton', () => $wrapper.find('a#show-tiles'))
+    def('showListButton', () => $wrapper.find('a#show-list'))
 
     it('loads the Filters', function() {
       assert.isTrue($wrapper.contains(Filters))
@@ -21,9 +21,8 @@ describe('Browse', () => {
         assert.isFalse($wrapper.contains(ListBrowser))
       })
 
-      it('disables the Tile view button', () => {
-        assert.equal($showTilesButton.attributes('disabled'), 'disabled')
-        assert.notExists($showListButton.attributes('disabled'))
+      it('activates the Tile view button', () => {
+        assert.deepEqual($showTilesButton.classes(), ['navbar-item', 'is-active'])
       })
     })
 
@@ -38,9 +37,8 @@ describe('Browse', () => {
         assert.isFalse($wrapper.contains(TileBrowser))
       })
 
-      it('disables the List view button', () => {
-        assert.equal($showListButton.attributes('disabled'), 'disabled')
-        assert.notExists($showTilesButton.attributes('disabled'))
+      it('activates the List view button', () => {
+        assert.deepEqual($showListButton.classes(), ['navbar-item', 'is-active'])
       })
     })
   })


### PR DESCRIPTION

![localhost_3000_contributions(iPad)](https://user-images.githubusercontent.com/2293844/94270026-1c200000-ff05-11ea-84ac-22be81e5f4e7.png)
![localhost_3000_contributions(iPad) (1)](https://user-images.githubusercontent.com/2293844/94270065-28a45880-ff05-11ea-8d35-3e11ad1fdd8c.png)
![localhost_3000_contributions(iPad) (2)](https://user-images.githubusercontent.com/2293844/94270072-2c37df80-ff05-11ea-98c9-49837413fd56.png)



## Why

Updates the contributions view layout for browse (tile|list|map) buttons, tiles and list view items. Relates to #282. 

### Pre-Merge Checklist

**All these boxes should be checked off before any pull request is merged!**

- [x] All new features have been described in the pull request
- [x] Security & accesibility have been considered
- [x] All outstanding questions and concerns have been resolved
- [x] Any next steps that seem like a good ideas have been created as issues for future discussion & implementation
- [x] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [x] New features have been documented, and the code is understandable and well commented
- [ ] Entry added to CHANGELOG.md if appropriate


## What

- [x] Update browse view buttons
- [x] Update Tile view
- [x] Update list view

## How

Update layout based on [contributions mocks](https://github.com/rubyforgood/mutual-aid/issues/707#issuecomment-697109318)

### Testing

Navigate to the `/contributions` view and visually inspect


