### PR TITLE
Remove unused test service

### DIFF
--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -80,21 +80,6 @@ services:
       - RAILS_ENV=development
       - WEBPACKER_DEV_SERVER_HOST=0.0.0.0
 
-  test:
-    build:
-      context: ../..
-      dockerfile: ./docker/development/app/Dockerfile
-    user: "${UID}"
-    depends_on:
-      - db
-      - email
-    environment:
-      <<: *x-shared-postgres-environment
-      <<: *x-email-defaults
-      RAILS_ENV: test
-      POSTGRES_HOST: db
-    command: bundle exec rspec
-
 volumes:
   db:
   gem_cache:


### PR DESCRIPTION
## Why

In a docker development environment, the test are run using the app
service - IE the use the same "image" as the running application - via
bin/dev/test. This service is no longer needed.

Resolves #739 

### Pre-Merge Checklist

**All these boxes should be checked off before any pull request is merged!**

- [ ] All new features have been described in the pull request
- [ ] Security & accesibility have been considered
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like a good ideas have been created as issues for future discussion & implementation
- [ ] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [ ] New features have been documented, and the code is understandable and well commented
- [ ] Entry added to CHANGELOG.md if appropriate

## How

`bin/dev/test` reuses the `app` service's image to spin up a container in which the tests are run. For `rspec`, the spec_helper already specifies that the application will run in the `test` environment, rather than the default.

### Testing

`bin/dev/test` should still run the test suite

## Next Steps

It might be nice to provide an interface to allow the developer to run a specific, or subset, of examples/specs in the test suite. I know this fuctionality exists via RSpec, but the `bin/dev/test` script currently assumes that you want to run the Rails and JavaScript test suites - IE test the whole application.

