### PR TITLE
Fix accessing null location

### DIFF
--- a/app/javascript/pages/browse/MapBrowser.vue
+++ b/app/javascript/pages/browse/MapBrowser.vue
@@ -49,7 +49,7 @@
 
             this.contributions.forEach(contribution => {
               geoCodingService.forwardGeocode({
-                query: `${contribution.location.street_address} ${contribution.service_area.location.city} ${contribution.service_area.location.state} ${contribution.service_area.location.zip_code}`,
+                query: `${contribution.location && contribution.location.street_address ? contribution.location.street_address : ""} ${contribution.service_area.location.city} ${contribution.service_area.location.state} ${contribution.service_area.location.zip_code}`,
                 limit: 1
               }).send()
                 .then(response => {


### PR DESCRIPTION
## Why
An error showed up in the web console when the map attempts to access `contribution.location.street_address` when `contribution.location` is null. This fix addresses that.
