### PR TITLE
Enhance docker development docs

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -182,6 +182,8 @@ To get started using the application with docker,
 2. Install [docker-compose](https://docs.docker.com/compose/install/)
 3. Clone the repository, and open the repository folder in your favorite command line or terminal application.
 
+We provide helpful shorthand, binstubs to get started using and interacting with the local Docker development environment:
+
 ### Bootstrapping the application for development
 
 ```

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -249,7 +249,7 @@ bin/dev/shell
 
 Starts a shell inside the application container and establishes a TTY connection to it from the user's terminal.
 
-Useful for things like generating migrations, exploring the container file system, etc.
+Useful for things like starting a rails console, generating migrations, running one-off tests, exploring the container file system, etc. This will most likely be the tool you most-often reach for while developing with the local Docker development setup.
 
 ### Deleting all application resources
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -199,7 +199,7 @@ SYSTEM_PASSWORD=mutualaid
 
 then run the bootstrapping process.
 
-**BEWARE**  This script is intended to be a quick way to start from nothing and get a working instance of the application - suitable for development - up and running. It is also appropriate if you should find yourself at a total loss and want to start over with your development environment. This destroys and recreates the volumes for the various containers - IE databases, gem caches, yarn caches will be destroyed - which can be costly in wall clock time.
+**BEWARE**  This script is intended to be a quick way to start from nothing and get a working instance of the application - suitable for development - up and running. It is also appropriate if you should find yourself at a total loss and want to start over with your development environment. This destroys the volumes for the various containers - IE the data on the databases, gem caches, yarn caches will be erased. Additionally, reinstalling gems and yarn dependencies can take several minutes. 
 
 ### Starting the application and its services
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -199,16 +199,6 @@ then run the bootstrapping process.
 
 **BEWARE**  This script is intended to be a quick way to start from noting and get a working instance of the application - suitable for development - up and running. It is also appropriate if you should find yourself at a total loss and want to start over with your development environment. This destroys and recreates the volumes for the various containers - IE databases, gem caches, yarn caches will be destroyed - which can be costly in wall clock time.
 
-### Running tests
-
-```
-bin/dev/test
-```
-
-Runs the tests inside the context of the `app` container
-
-Analogous to: `bin/test`
-
 ### Starting the application and its services
 
 ```
@@ -250,6 +240,17 @@ bin/dev/stop
 ```
 
 Stops the web application container and its supporting services - RDBMS, mailcatcher, webpacker, etc.
+
+
+### Running tests
+
+```
+bin/dev/test
+```
+
+Runs the tests inside the context of the `app` container
+
+Analogous to: `bin/test`
 
 ### Deleting all application resources
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -250,7 +250,7 @@ Stops the web application container and its supporting services - RDBMS, mailcat
 bin/dev/test
 ```
 
-Runs the tests inside the context of the `app` container
+Runs the entire application test suite inside the context of the `app` container
 
 Analogous to: `bin/test`
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -175,7 +175,7 @@ The Rails and webpack processes can be launched with Heroku, if you choose to go
 
 ## Development with Docker
 
-The application includes a pre-configured [docker-compose](https://docs.docker.com/compose/) environment. This environment includes two containers, which together deploy the application and a postgres database for it to connect to.
+The application includes a pre-configured [docker-compose](https://docs.docker.com/compose/) environment for development. This environment includes descriptors for the application and its supporting services.
 
 To get started using the application with docker,
 1. Install [Docker](https://www.docker.com/get-started)

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -233,14 +233,6 @@ and in the second terminal start `email` and `webpacker`
 bin/dev/serve email webpacker
 ```
 
-### Stopping the application and its services
-
-```
-bin/dev/stop
-```
-
-Stops the web application container and its supporting services - RDBMS, mailcatcher, webpacker, etc.
-
 ### Obtaining a shell
 
 ```
@@ -250,6 +242,14 @@ bin/dev/shell
 Starts a shell inside the application container and establishes a TTY connection to it from the user's terminal.
 
 Useful for things like starting a rails console, generating migrations, running one-off tests, exploring the container file system, etc. This will most likely be the tool you most-often reach for while developing with the local Docker development setup.
+
+### Stopping the application and its services
+
+```
+bin/dev/stop
+```
+
+Stops the web application container and its supporting services - RDBMS, mailcatcher, webpacker, etc.
 
 ### Deleting all application resources
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -263,7 +263,7 @@ Destroys all docker resources for the application and services.
 ### Notes
 
 - Do not use this method in production! This is for **testing & development only** the configuration used with in this docker-compose file is highly insecure and should never be exposed to the public internet.
-- Of course, all of the above binstubs are simply short hands for various `docker-compose` incantations - there's nothing stopping you from using `docker-compose` to interact with the services listed in the [`docker/development/docker-compose.yml`](../docker/development/docker-compose.yml).
+- All of the above binstubs are simply short hands for various `docker-compose` incantations - there's nothing stopping you from using `docker-compose` to interact with the services listed in the [`docker/development/docker-compose.yml`](../docker/development/docker-compose.yml).
 - The application will save its state between successive invocations of `bin/dev/start`. This means that if you make changes to the database - for example by adding content or users - then those changes will persist the next time you start the application with `bin/dev/start`. You can wipe all the state of the application and all the services (including the postgres database) attached to it by running `bin/dev/clean` or `bin/dev/bootstrap` to start over from scratch. However, do be careful, because this will delete **all** the state saved in the application and database - and there is no way to retrieve it.
 
 <sub>↩ Back to [README](/README.md)</sub>

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -262,8 +262,8 @@ Destroys all docker resources for the application and services.
 
 ### Notes
 
-- Of course, all of the above binstubs are simply short hands for various `docker-compose` incantations - there's nothing stopping you from using `docker-compose` to interact with the services listed in the [`docker/development/docker-compose.yml`](../docker/development/docker-compose.yml).
 - Do not use this method in production! This is for **testing & development only** the configuration used with in this docker-compose file is highly insecure and should never be exposed to the public internet.
+- Of course, all of the above binstubs are simply short hands for various `docker-compose` incantations - there's nothing stopping you from using `docker-compose` to interact with the services listed in the [`docker/development/docker-compose.yml`](../docker/development/docker-compose.yml).
 - The application will save its state between successive invocations of `bin/dev/start`. This means that if you make changes to the database - for example by adding content or users - then those changes will persist the next time you start the application with `bin/dev/start`. You can wipe all the state of the application and all the services (including the postgres database) attached to it by running `bin/dev/clean` or `bin/dev/bootstrap` to start over from scratch. However, do be careful, because this will delete **all** the state saved in the application and database - and there is no way to retrieve it.
 
 <sub>↩ Back to [README](/README.md)</sub>

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -197,6 +197,8 @@ SYSTEM_PASSWORD=mutualaid
 
 then run the bootstrapping process.
 
+**BEWARE**  This script is intended to be a quick way to start from noting and get a working instance of the application - suitable for development - up and running. It is also appropriate if you should find yourself at a total loss and want to start over with your development environment. This destroys and recreates the volumes for the various containers - IE databases, gem caches, yarn caches will be destroyed - which can be costly in wall clock time.
+
 ### Running tests
 
 ```

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -199,7 +199,7 @@ SYSTEM_PASSWORD=mutualaid
 
 then run the bootstrapping process.
 
-**BEWARE**  This script is intended to be a quick way to start from noting and get a working instance of the application - suitable for development - up and running. It is also appropriate if you should find yourself at a total loss and want to start over with your development environment. This destroys and recreates the volumes for the various containers - IE databases, gem caches, yarn caches will be destroyed - which can be costly in wall clock time.
+**BEWARE**  This script is intended to be a quick way to start from nothing and get a working instance of the application - suitable for development - up and running. It is also appropriate if you should find yourself at a total loss and want to start over with your development environment. This destroys and recreates the volumes for the various containers - IE databases, gem caches, yarn caches will be destroyed - which can be costly in wall clock time.
 
 ### Starting the application and its services
 


### PR DESCRIPTION
## Why

My first pass at documenting how to use the Docker development environment imparts a feeling of importance on certain less important parts of the setup. This seeks to clarify that the binstubs are shorthand helpers to get up and running quickly or make broad strokes across the codebase. As it stands now `bin/dev/shell`, and `bin/dev/serve` are probably the tools with which developers will want to interact. This elevates their place in the docs and adds some additional uses, warnings, etc. 

### Pre-Merge Checklist

**All these boxes should be checked off before any pull request is merged!**

- [ ] All new features have been described in the pull request
- [ ] Security & accesibility have been considered
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like a good ideas have been created as issues for future discussion & implementation
- [ ] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [ ] New features have been documented, and the code is understandable and well commented
- [ ] Entry added to CHANGELOG.md if appropriate
