### PR TITLE
Replace guard with the much lighter rerun gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,8 @@ end
 
 group :development do
   gem 'annotate'
-  gem 'guard-rspec', require: false
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'rerun'
   gem 'spring'
   gem 'spring-commands-rspec', require: false
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,23 +106,8 @@ GEM
     faker (2.11.0)
       i18n (>= 1.6, < 2)
     ffi (1.12.2)
-    formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    guard (2.16.2)
-      formatador (>= 0.2.4)
-      listen (>= 2.7, < 4.0)
-      lumberjack (>= 1.0.12, < 2.0)
-      nenv (~> 0.1)
-      notiffany (~> 0.0)
-      pry (>= 0.9.12)
-      shellany (~> 0.0)
-      thor (>= 0.18.1)
-    guard-compat (1.2.1)
-    guard-rspec (4.7.3)
-      guard (~> 2.1)
-      guard-compat (~> 1.1)
-      rspec (>= 2.99.0, < 4.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     jbuilder (2.10.0)
@@ -134,7 +119,6 @@ GEM
     loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    lumberjack (1.2.4)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
@@ -148,13 +132,9 @@ GEM
       i18n (>= 0.6.10, < 2)
       request_store (~> 1.0)
     msgpack (1.3.3)
-    nenv (0.3.0)
     nio4r (2.5.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
-    notiffany (0.1.3)
-      nenv (~> 0.1)
-      shellany (~> 0.0)
     orm_adapter (0.5.0)
     pg (1.2.3)
     pry (0.13.0)
@@ -213,13 +193,11 @@ GEM
       uber (< 0.2.0)
     request_store (1.5.0)
       rack (>= 1.4)
+    rerun (0.13.0)
+      listen (~> 3.0)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
     rspec-expectations (3.9.1)
@@ -243,7 +221,6 @@ GEM
     ruby_http_client (3.5.0)
     sendgrid-ruby (6.2.0)
       ruby_http_client (~> 3.4)
-    shellany (0.0.1)
     simple_form (5.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -296,7 +273,6 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
-  guard-rspec
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   mobility (~> 0.8.9)
@@ -307,6 +283,7 @@ DEPENDENCIES
   rack-timeout
   rails (~> 6.0.2, >= 6.0.2.2)
   reform-rails
+  rerun
   rspec-rails
   rspec_junit_formatter
   sendgrid-ruby


### PR DESCRIPTION
## Why

`guard` with [`guard-rspec`](https://github.com/alexch/rerun) is a fine solution but presented a few imperfections:
1. It would slow down over time; every automatically triggered run would take slightly longer.
1. By default it uses a 1 to 1 mapping of spec to app code. This is often a good choice, but i often want to run a _set_ of specs as i make related changes. This is difficult to achieve with guard.
1. It has a non-trivial configuration scheme. This is not often a problem since plugin gems usually generate configuration for us, but when we do need to tweak something, there's a significant api to learn.

[`rerun`](https://github.com/alexch/rerun) is a much simpler tool that addresses all of the above.

## Outstanding Questions, Concerns and Other Notes

I'm not aware of any core/recent contributors using guard, but if anyone is, we can certainly keep it alongside `rerun`.
In fact the latter doesn't even need to be in the project Gemfile; there's just a slight advantage to putting such tooling in here to reduce external tooling (eg in a docker container).
