### PR TITLE
Fix mailcatcher for local development

### DIFF
--- a/.env
+++ b/.env
@@ -11,7 +11,8 @@ PORT=3000
 # DB hostname required for CircleCI. Feel free to override it in .env.test.local
 POSTGRES_HOST=localhost
 
-# Email (recommend SendGrid) api key
+# Override this in .env.local if you prefer to run mailcatcher only when testing email
+RAISE_MAIL_DELIVERY_ERRORS=true
 SMTP_HOST=localhost
 SMTP_PORT=1025
 SMTP_USERNAME=123

--- a/.env
+++ b/.env
@@ -6,6 +6,7 @@ SYSTEM_APP_NAME=mutual-aid-app
 SYSTEM_EMAIL=mutualaidtesting@example.com
 SYSTEM_PASSWORD=testing123
 SYSTEM_HOST_NAME=localhost
+PORT=3000
 
 # DB hostname required for CircleCI. Feel free to override it in .env.test.local
 POSTGRES_HOST=localhost

--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ SMTP_PORT=587
 SMTP_USERNAME=123
 SMTP_PASSWORD=123
 SMTP_FROM_EMAIL=mutualaidapptesting@example.com
-SMTP_ADDRESS=smtp.sendgrid.net
+SMTP_HOST=smtp.sendgrid.net
 SENDGRID_API_KEY=123
 
 # (optional) override devise hours after which link expires (defaults to 6)

--- a/.env
+++ b/.env
@@ -11,11 +11,11 @@ SYSTEM_HOST_NAME=localhost
 POSTGRES_HOST=localhost
 
 # Email (recommend SendGrid) api key
-SMTP_PORT=587
+SMTP_HOST=localhost
+SMTP_PORT=1025
 SMTP_USERNAME=123
 SMTP_PASSWORD=123
 SMTP_FROM_EMAIL=mutualaidapptesting@example.com
-SMTP_HOST=smtp.sendgrid.net
 SENDGRID_API_KEY=123
 
 # (optional) override devise hours after which link expires (defaults to 6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Breaking changes
 * Users can now register themselves (was previously blocked by #660)
+* The `SMTP_ADDRESS` environment variable has been renamed to `SMTP_HOST` #750
+    - Existing deploymed environments will have to be updated and restarted/redeployed.
 
 ### Bugfixes
 * Get outgoing email working #660, #676

--- a/app/views/submission_mailer/_generic_confirmation_email.html.erb
+++ b/app/views/submission_mailer/_generic_confirmation_email.html.erb
@@ -10,7 +10,7 @@
       We’ll contact you within a few days to see if we can be of assistance.
     <% elsif @system_setting.peer_to_peer? %>
       We hope you're contacted soon by a neighbor!
-    <% elsif @system_setting.hybrid? %>
+    <% else %>
       We hope you're contacted soon by a neighbor or by our group. If your need is urgent and you still haven't been contacted, reach out to us directly.
     <% end %>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,24 @@ module Mutualaid
     config.i18n.fallbacks = true
 
     config.time_zone = 'UTC'
+
+    # ActionMailer config
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.perform_caching = false
+    config.action_mailer.perform_deliveries = true
+    config.action_mailer.raise_delivery_errors = true
+    config.action_mailer.smtp_settings = {
+      address:   ENV['SMTP_HOST'],
+      port:      (ENV['SMTP_PORT'].presence || 587).to_i,
+      user_name: ENV['SMTP_USERNAME'],
+      password:  ENV['SMTP_PASSWORD'],
+      domain:    ENV['SYSTEM_HOST_NAME'],
+      authentication: 'plain',
+      enable_starttls_auto: true,
+    }
+    config.action_mailer.default_url_options = {
+      host: ENV['SYSTEM_HOST_NAME'],
+      port: (ENV['PORT'].presence || 80).to_i,
+    }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,7 +51,7 @@ module Mutualaid
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.perform_caching = false
     config.action_mailer.perform_deliveries = true
-    config.action_mailer.raise_delivery_errors = true
+    config.action_mailer.raise_delivery_errors = ENV['RAISE_MAIL_DELIVERY_ERRORS'] != 'false'
     config.action_mailer.smtp_settings = {
       address:   ENV['SMTP_HOST'],
       port:      (ENV['SMTP_PORT'].presence || 587).to_i,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
 
   # connect action mailer to the development SMTP server
   config.action_mailer.smtp_settings = {
-    address: ENV['SMTP_ADDRESS'],
+    address: ENV['SMTP_HOST'],
     port:    (ENV['SMTP_PORT'].presence || 587).to_i,
     domain:  ENV['SYSTEM_HOST_NAME'],
   }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,27 +31,6 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
-  config.action_mailer.perform_caching = false
-
-  # per mailcatcher documentation https://mailcatcher.me/
-  config.action_mailer.delivery_method = :smtp
-
-  # connect action mailer to the development SMTP server
-  config.action_mailer.smtp_settings = {
-    address: ENV['SMTP_HOST'],
-    port:    (ENV['SMTP_PORT'].presence || 587).to_i,
-    domain:  ENV['SYSTEM_HOST_NAME'],
-  }
-
-  # per devise's suggested settings
-  config.action_mailer.default_url_options = {
-    host: ENV['SYSTEM_HOST_NAME'],
-    port: (ENV['PORT'].presence || 3000).to_i
-  }
-
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,25 +54,6 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "mutualaid_production"
 
-  config.action_mailer.perform_caching = false
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.default :charset => "utf-8"
-  config.action_mailer.perform_deliveries = true
-  config.action_mailer.default_url_options = { host: ENV['SYSTEM_HOST_NAME'] }
-  config.action_mailer.smtp_settings = {
-      address:              ENV['SMTP_HOST'],
-      port:                 "#{ENV['SMTP_PORT'] || 587}".to_i,
-      domain:               ENV['SYSTEM_HOST_NAME'],
-      user_name:            ENV['SMTP_USERNAME'],
-      password:             ENV['SMTP_PASSWORD'],
-      authentication:       'plain',
-      enable_starttls_auto: true
-  }
-
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
   config.action_mailer.default_url_options = { host: ENV['SYSTEM_HOST_NAME'] }
   config.action_mailer.smtp_settings = {
-      address:              ENV['SMTP_ADDRESS'],
+      address:              ENV['SMTP_HOST'],
       port:                 "#{ENV['SMTP_PORT'] || 587}".to_i,
       domain:               ENV['SYSTEM_HOST_NAME'],
       user_name:            ENV['SMTP_USERNAME'],

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,19 +33,18 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 
-  config.action_mailer.perform_caching = false
-
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.perform_caching = false
+  # Required here for CircleCI; FIXME: set via env vars instead
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
-
-  # Required here for CircleCI
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 end

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -104,9 +104,6 @@ We recommend:
 
 ## Setting up Mailcatcher
 
-You only need mailcatcher if you're doing a lot of work on emails in the development environment.
-Without it, emails will be logged in the server log (log/development.log), but mailcatcher makes mailer work SO much easier.
-
 Mailcatcher cannot be bundled, so has to be installed globally:
 ```
 $ gem install mailcatcher
@@ -117,7 +114,11 @@ Start the mail server with:
 $ mailcatcher
 ```
 And go to http://localhost:1080/
-Mail can be sent through smtp://localhost:1025
+
+By default, some user actions, such as registration, will fail if mailcatcher is not running.
+This is an intentional choice to keep development as close to production as possible.
+If you prefer to fire up mailcatcher only when you're working on emails, you can override this behavior
+via [environment variables](#environment-variables).
 
 
 ## Environment variables

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -13,8 +13,8 @@ x-shared-environment-defaults:
   - &WEBPACKER_DEV_SERVER_PORT "${WEBPACKER_DEV_SERVER_PORT:-3035}"
 
 x-email-defaults: &x-email-defaults
+  SMTP_HOST: "${EMAIL_HOST:-email}"
   SMTP_PORT: *EMAIL_SMTP_PORT
-  SMTP_ADDRESS: "${EMAIL_HOST:-email}"
   SMTP_FROM_EMAIL: "${EMAIL_FROM_ADDR:-mutualaid@localhost}"
   SYSTEM_HOST_NAME: "${SYSTEM_HOST_NAME:-localhost}"
 


### PR DESCRIPTION
## Why
Fixes `mailcatcher` setup for local (non-docker) development and introduces several related refactorings.

I believe our mailcatcher setup broke in a recent change and was trying to connect to sendgrid. This went unnoticed because we were testing from the local docker env, where the smtp host/port are configured to point at the `email` service.

## Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [x] All outstanding questions and concerns have been resolved
- [x] Any next steps that seem like good ideas have been created as issues for future discussion & implementation
- [x] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [x] New features have been documented, and the code is understandable and well commented
- [x] Entry added to CHANGELOG.md if appropriate

## What
Also includes these related changes:
* Rename SMTP_ADDRESS env var -> SMTP_HOST, 56d0286
  Since it deals with email addresses, i found the existing variable name to be confusing. Host is also more commonly used, alongside port.
* Remove unimplemented reference to `SystemSetting#hybrid?`, 10a8766
  This was breaking the new submission mailer.
* Consolidate smtp config between dev and prod, 81e37bb
  All the relevant settings are configured via environment variables so we can move towards a single config block in application.rb. This moves us closer to 12factor, reducing the surface area for bugs and misconfiguration.
      Note the new `PORT` entry in `.env` which supports default_url_options in mailers. This is pretty generic variable name which makes me a bit nervous but was already being referenced in the app.
* Allow skipping mailcatcher until needed, c8462ea
  Since the change above now requires mailcatcher to be running by default, provide a way to override this locally.

## Testing
Manually tested locally with and without docker, with good/bad values for environment variables.

## Outstanding Questions, Concerns and Other Notes
* `config/environment/test.rb` currently overrides smtp.default_url_options for CircleCI. Ideally this can be handled with environment variables instead.
* Maybe consider renaming the `PORT` environment variable to something less generic?
