### PR TITLE
Tweak pull_request_template to signal more leeway on what to include

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,22 @@
 ## Why
-
 <!--
-A summary of what problem this pull request is trying to solve. **Always** include a #reference to an existing issue, which should provide a more detailed explanation of the problem, as well as any discussion about the nature of the problem.
+A summary of what problem this pull request is trying to solve. Include a #reference to an existing issue, which should provide a more detailed explanation of the problem, as well as any discussion about the nature of the problem.
 
 If appropriate, use github's [issue linking keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to automatically close any issues that this pull request resolves.
 -->
 
 ### Pre-Merge Checklist
-
-**All these boxes should be checked off before any pull request is merged!**
+<!-- All these boxes should be checked off before any pull request is merged! -->
 
 - [ ] All new features have been described in the pull request
-- [ ] Security & accesibility have been considered
+- [ ] Security & accessibility have been considered
 - [ ] All outstanding questions and concerns have been resolved
-- [ ] Any next steps that seem like a good ideas have been created as issues for future discussion & implementation
+- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation
 - [ ] High quality tests have been added, or an explanation has been given why the features cannot be tested
 - [ ] New features have been documented, and the code is understandable and well commented
 - [ ] Entry added to CHANGELOG.md if appropriate
 
-
 ## What
-
 <!--
 A list of the changes included in this pull request. A checkbox list is probably a good choice here, and the boxes should be checked off as tasks are completed. This section may be omitted if the Why section provides enough information and only a few changes were made (eg, for simple bug reports).
 
@@ -34,36 +30,26 @@ Also, include screenshots if you can!
 -->
 
 ## How
-
 <!--
-Describe how you solved the problem. This is not a replacement for documentation, but should give people context and a high-level understanding of your solution before/without reading your code. In particular, if your solution implements or makes use of any algorithms, protocols or paradigms that some developers may be unfamiliar with (such as using a cryptographic hash function, implementing a particular high performance datastructure or using functional programming concepts, etc) you should mention it here, and ideally one or two links that point people to learning resources. Also, if you found anything difficult, or you feel that your solution is "clever", you should probably talk about it here, and explain what you did.
+Describe how you solved the problem. This is not a replacement for documentation, but should give people context and a high-level understanding of your solution before/without reading your code. In particular, if your solution implements or makes use of any algorithms, protocols or paradigms that some developers may be unfamiliar with (such as using a cryptographic hash function, implementing a particular high performance data structure or using functional programming concepts, etc) you should mention it here, and ideally one or two links that point people to learning resources. Also, if you found anything difficult, or you feel that your solution is "clever", you should probably talk about it here, and explain what you did.
 -->
 
 ### Testing
-
 <!--
 If possible you should add tests to ensure that any changes you make work as expected! Describe the tests you added, or make note of anything you couldn't figure out how to test. You don't need to go into a whole lot of detail (good tests should be pretty self explanatory) but at a minimum make note of where you put any new tests in the code base.
 
 IF YOU CHANGED THE BEHAVIOR OF ANY TESTS THAT WERE PREVIOUSLY IMPLEMENTED ALWAYS MAKE A NOTE OF IT AND DESCRIBE WHAT YOU CHANGED AND WHY!
 -->
 
-
 ## Next Steps
-
-<!-- THIS SECTION IS OPTIONAL. DELETE IF NOT USED.
-
+<!--
 This section is to highlight any ideas you have for how this feature could be extended in the future.
 
 You should also consider adding issues for these next steps
 -->
 
-
 ## Outstanding Questions, Concerns and Other Notes
-
-<!-- THIS SECTION IS OPTIONAL. DELETE IF NOT USED.
-
-In particular, you should
-
+<!--
 Any questions or concerns you were unable to address while implementing this solution. For example, "I've implemented heat vision resistance, but do we expect to be attacked by superman?"
 
 If you find that this section is getting long, or the questions and concerns have a significant impact on the quality of this solution, consider making this a ["draft"](https://github.blog/2019-02-14-introducing-draft-pull-requests/) pull request to ensure that it is not merged until it is ready.
@@ -72,24 +58,16 @@ This may be another place where a checklist is a good choice, so people can see 
 -->
 
 ### Accessibility
-
-<!-- THIS SECTION IS OPTIONAL. DELETE IF NOT USED.
-
-If this change will make any significant changes to either physical accesibility (eg, making the website work better with screenreaders) and technical accesibility (eg, making the website load faster for people with marginal internet), you should explain what they are, and highlight any issues or concerns you might have that haven't been resolved.
-
+<!--
+If this change will make any significant changes to either physical accessibility (eg, making the website work better with screenreaders) or technical accessibility (eg, making the website load faster for people with marginal internet), you should explain what they are, and highlight any issues or concerns you might have that haven't been resolved.
 -->
 
-
 ### Security
-
-<!-- THIS SECTION IS OPTIONAL. DELETE IF NOT USED.
-
-Address how this change will improve/lessen the security of the application - for example, it improves HTML sanatization or opens a new attack surface. Always explain so that developers without a security background can understand. Similarly, address how this change will impact the accessibility of the application. Be sure to address both physical accesibility (eg, making the website work better with screenreaders) and technical accesibility (eg, making the website load faster for people with marginal internet). If you're not sure what to put here, don't worry! Just explain what you can, and make sure to note that you think this issue needs to be reviewed with security & accesibility in mind
+<!--
+Address how this change will improve/lessen the security of the application - for example, it improves HTML sanitization or opens a new attack surface. Always explain so that developers without a security background can understand. Similarly, address how this change will impact the accessibility of the application. Be sure to address both physical accessibility (eg, making the website work better with screenreaders) and technical accessibility (eg, making the website load faster for people with marginal internet). If you're not sure what to put here, don't worry! Just explain what you can, and make sure to note that you think this issue needs to be reviewed with security & accessibility in mind
 -->
 
 ### Meta
-
-<!-- THIS SECTION IS OPTIONAL. DELETE IF NOT USED.
-
-Any additional notes you have regarding your experience working on this pull request as a contributer. If this is very detailed, it would be a good idea to create an issue to address it
+<!--
+Any additional notes you have regarding your experience working on this pull request as a contributer. If this is very detailed, it could be a good idea to create an issue to address it.
 -->


### PR DESCRIPTION
## Why
The pull request template marks certain sections as optional, implying the others are mandatory. As i've been using the template, i'm finding that some of the sections don't make sense in all contexts.

This removes mentions of optionality, hopefully giving authors more agency in choosing what to include and what to ignore. The template is already quite long and i'm worried about it being overwhelming and therefore being ignored over time or not taken seriously; this is an attempt to signal that it's more a guide and set of reminders than a mandate.

## Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] All new features have been described in the pull request
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation


## Outstanding Questions, Concerns and Other Notes
Curious your thoughts in particular @grenewode 
