### PR TITLE
Enhance docker bootstrap to also build webpack, email images

### DIFF
--- a/bin/dev/bootstrap
+++ b/bin/dev/bootstrap
@@ -2,15 +2,21 @@
 
 set -e
 
-function setup() {
-    local environment
-    environment="$1"
-
-    docker-compose -f docker/development/docker-compose.yml \
-                   run --rm \
-                   app bin/rails db:reset RAILS_ENV="${environment}"
+function dc() {
+  docker-compose -f docker/development/docker-compose.yml run --rm "$@"
 }
 
+# start fresh
 bin/dev/clean
-setup development
-setup test
+
+# will create the app container, create both dev and test databases, and seed dev
+dc app bin/rails db:reset
+
+# only the test db needs to be explicitly seeded
+dc app bin/rails db:seed RAILS_ENV=test
+
+# build the image and make sure webpack can compile; don't start webpack-dev-server
+dc webpacker bin/webpack
+
+# build the image; don't start mailcatcher yet
+dc email echo done!


### PR DESCRIPTION

## Why
Currently, `bin/dev/bootstrap` only builds the `app` image and when we run `bin/dev/serve` or other dependent command, the `webpack` and `email` images are built. While there's value in building these 'just-in-time', i'd prefer bootstrap build all three images.

This will surface any issues when a user first sets up their docker env and subsequent commands will fire up more quickly.

## Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] All new features have been described in the pull request
- [x] New features have been documented, and the code is understandable and well commented
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation

## Testing
Tested locally but would love another set of eyes to verify.

## Outstanding Questions, Concerns and Other Notes
* The `dc` function in `bin/dev/bootstrap` uses the `$@` variable which seems to work but is new to me; is this an approprate use? Are there any gotcha's with it?

