### PR TITLE
Fix multiple image builds when starting docker

### DIFF
--- a/bin/dev/bootstrap
+++ b/bin/dev/bootstrap
@@ -3,20 +3,38 @@
 set -e
 
 function dc() {
-  docker-compose -f docker/development/docker-compose.yml run --rm "$@"
+    docker-compose -f docker/development/docker-compose.yml $@
+}
+
+function build_images() {
+    # Build all local docker images
+    dc build
+}
+
+function prepare_database_schema() {
+    # Recreate both development and test databases from scratch; then
+    # seed the development database.
+    dc run --rm app bin/rails db:reset
+}
+
+function seed_test_database() {
+    dc run --rm app bin/rails db:seed RAILS_ENV=test
+}
+
+function prepare_databases() {
+    prepare_database_schema
+    seed_test_database
+}
+
+function build_webpack() {
+    # Ensure that the webpacker serivce can build the packs
+    dc run --rm webpacker bin/webpack
 }
 
 # start fresh
 bin/dev/clean
 
-# will create the app container, create both dev and test databases, and seed dev
-dc app bin/rails db:reset
-
-# only the test db needs to be explicitly seeded
-dc app bin/rails db:seed RAILS_ENV=test
-
-# build the image and make sure webpack can compile; don't start webpack-dev-server
-dc webpacker bin/webpack
-
-# build the image; don't start mailcatcher yet
-dc email echo done!
+build_images
+prepare_databases
+build_webpack
+echo "done!"

--- a/docker/development/app/Dockerfile
+++ b/docker/development/app/Dockerfile
@@ -1,31 +1,22 @@
-FROM ruby:2.7.0-alpine
+FROM ruby:2.7.0-alpine as base
 
-ARG APP_PORT=3000
-
-RUN bundle config --global frozen 1
 WORKDIR /usr/src/app
 
 RUN apk add --update-cache postgresql-dev zlib build-base tzdata nodejs yarn
 
-ENV RAILS_ENV='' \
-    POSTGRES_HOST='' \
-    POSTGRES_PASSWORD='' \
-    POSTGRES_USER='postgres' \
-    POSTGRES_DB='' \
-    EMAIL_HTTP_PORT='' \
-    EMAIL_SMTP_PORT='' \
-    EMAIL_HOST='' \
-    EMAIL_FROM_ADDR='' \
-    EMAIL_DEFAULT_URL_HOST=''
+ENV BUNDLE_PATH='/usr/local/bundle' \
+  RAILS_ENV='' \
+  POSTGRES_HOST='' \
+  POSTGRES_PASSWORD='' \
+  POSTGRES_USER='postgres' \
+  POSTGRES_DB='' \
+  EMAIL_HTTP_PORT='' \
+  EMAIL_SMTP_PORT='' \
+  EMAIL_HOST='' \
+  EMAIL_FROM_ADDR='' \
+  EMAIL_DEFAULT_URL_HOST=''
 
 COPY Gemfile Gemfile.lock ./
 COPY package.json yarn.lock ./
 RUN bundle install
 RUN yarn install
-
-COPY . ./
-
-EXPOSE ${APP_PORT}
-ENV PORT ${APP_PORT}
-
-CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -51,7 +51,7 @@ services:
         published: *APP_PORT
     volumes:
       - ../..:/usr/src/app
-      - gem_cache:/usr/local/bundle/gems
+      - gem_cache:/usr/local/bundle/
       - node_modules:/usr/src/app/node_modules
     depends_on:
       - db
@@ -74,7 +74,7 @@ services:
     command: ./bin/webpack-dev-server
     volumes:
       - ../..:/usr/src/app
-      - gem_cache:/usr/local/bundle/gems
+      - gem_cache:/usr/local/bundle/
       - node_modules:/usr/src/app/node_modules
     ports:
       - target: *WEBPACKER_DEV_SERVER_PORT

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -21,8 +21,9 @@ x-email-defaults: &x-email-defaults
 services:
   email:
     build:
-      context: .
-      dockerfile: ./email/Dockerfile
+      context: ../..
+      dockerfile: ./docker/development/email/Dockerfile
+    command: [ "mailcatcher", "--foreground", "--ip", "0.0.0.0" ]
     depends_on:
       - db
     ports:
@@ -43,8 +44,8 @@ services:
     build:
       context: ../..
       dockerfile: ./docker/development/app/Dockerfile
-      args:
-        APP_PORT: *APP_PORT
+      target: base
+    command: [ "bundle", "exec", "rails", "server", "-b", "0.0.0.0" ]
     user: "${UID}"
     ports:
       - target: *APP_PORT
@@ -68,10 +69,9 @@ services:
     build:
       context: ../..
       dockerfile: ./docker/development/app/Dockerfile
-      args:
-        APP_PORT: *WEBPACKER_DEV_SERVER_PORT
+      target: base
     user: "${UID}"
-    command: ./bin/webpack-dev-server
+    command: [ "./bin/webpack-dev-server" ]
     volumes:
       - ../..:/usr/src/app
       - gem_cache:/usr/local/bundle/


### PR DESCRIPTION
## Why

The current Docker-based development setup essentially does the same things multiple times to produce images for the `app` and `webpacker` services. The goal of this body of work is to produce images for these services and allow the to reuse existing, cached artifacts to prevent the build phase from doing unnecessary work. 

### Pre-Merge Checklist

- [x] All new features have been described in the pull request
- [ ] Security & accessibility have been considered
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation
- [ ] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [ ] New features have been documented, and the code is understandable and well commented
- [ ] Entry added to CHANGELOG.md if appropriate

## What

- [x] Share ruby gems cache between `app` and `webpacker` services
- [x] Reuse cached Docker images layers between `app` and `webpacker` services
- [x] Pre-build all local development images as part of the development environment setup

## How

### Share ruby gems cache between `app` and `webpacker` services

The docker-compose setup includes a persistent volume intended to serve as a cache for bundler and rubygems. However, the volume mount contains a small error which is causing gems to be installed on the ephemeral filesystem - IE the gem cache is lost when a container exits. This means that every request to start an app container needs to re-install rubygems - and therefore re-run every step that comes after in the Dockerfile. This leads to longer than necessary wait times for the image to come up since the `bundle install` instruction of the Docerfile will never produce a cache-able layer.

This fixes the path so that gems are stored on the persistent volume and significantly decreases the amount of time one needs to wait for `app` / `webapcker` images and containers to become available. 

### Reuse cached Docker images layers between `app` and `webpacker` services

In development, the app and webpacker services run in the same context. Instead of building an image for each service, we now build one image and share it - then let docker-compose figure out what to run, which ports to expose, etc.

This uses [Docker multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) to create the "base" image, then the `app` and `webpacker` services both use the "base" image as a starting point for their containers.

### Pre-build all local development images as part of the development environment setup

~Instead of deferring image builds until the last possible moment, this changes the `bin/dev/bootstrap` script to pre-build all locally produced images for development.~ [A separate body of work to address this problem was completed and merged into `main`](https://github.com/rubyforgood/mutual-aid/pull/757 ) as THIS body of work was still evolving. Instead, focus for this change set shifted to providing a small reorganization to the work done in #757.

### Testing

1. Run `bin/dev/bootstrap`, one should see that `bundle install` is performed only once between the `app` and `webpacker` as they build their images. 
2. Run `bin/dev/serve` notice that the `docker-compose up --build` step reuses layer caches for the `app`, `webpacker`, and `email` services
