### PR TITLE
Disable user sign_up until pundit work is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@
 * Ask|Offer form submissions now send an email to the contributor and log the communication #758
 
 ### Breaking changes
-* Users can now register themselves (was previously blocked by #660)
 * The `SMTP_ADDRESS` environment variable has been renamed to `SMTP_HOST` #750
     - Existing deploymed environments will have to be updated and restarted/redeployed.
 
 ### Bugfixes
 * Get outgoing email working #660, #676
+* User signup is now working (was previously blocked by #660), however has been disabled ↙️
+* Disable user signup until we get authorizations working #767
 
 ### Development notes
 * Switched primary branch from `master` to `main` #658

--- a/app/controllers/registrations_sans_signup_controller.rb
+++ b/app/controllers/registrations_sans_signup_controller.rb
@@ -1,0 +1,13 @@
+# FIXME: remove this when the pundit work is ready, #514
+# Devise override based on https://stackoverflow.com/a/8291318
+class RegistrationsSansSignupController < Devise::RegistrationsController
+  def new
+    redirect_to new_user_session_path,
+      notice: 'Registrations have been temporarily disabled. Please check back soon or contact the app administrator'
+  end
+
+  def create
+    redirect_to new_user_session_path,
+      notice: 'Registrations have been temporarily disabled. Please check back soon or contact the app administrator'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
 
-  devise_for :users
+  # FIXME: drop controller override when the pundit work is ready, #514
+  devise_for :users, controllers: {registrations: "registrations_sans_signup"}
 
   get "/admin",                    to: "admin#landing_page",    as: "landing_page_admin"
   get "/admin/forms",              to: "admin#form_admin",      as: "form_admin"


### PR DESCRIPTION
## Why
Since #660 was fixed, users can now sign themselves up, but we don't have working authorizations so any new user would have sys-admin privileges.

To avoid this, we are temporarily disabling sign ups. They were actually broken in previous releases, so this change effectively maintains the current behavior.

This work can be reverted once #514 is merged.

### Pre-Merge Checklist
- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation
- [x] Entry added to CHANGELOG.md if appropriate

## How
- New controller that overrides `Devise::RegistrationsController`, giving notice to the user that sign ups are disabled.
- Based on [this SO solution](https://stackoverflow.com/a/8291318)

## Security
See why section above.