### PR TITLE
Fixes db seeds rake tasks for development

### DIFF
--- a/db/seeds/dev_seeds.rb
+++ b/db/seeds/dev_seeds.rb
@@ -168,7 +168,7 @@ end
 end
 
 Person.where.not(email: nil).sample(7).each do |person|
-  User.where(email: person.email).first_or_create!(confirmed_at: person.created_at, password: person.name.parameterize)
+  User.where(email: person.email).first_or_create!(confirmed_at: person.created_at, password: "password-#{person.name.parameterize}")
 end
 
 # autoemail logs per Listing

--- a/db/seeds/dev_seeds.rb
+++ b/db/seeds/dev_seeds.rb
@@ -32,8 +32,8 @@ state = ["NY", "MI", "DC", "NC"].sample
   Person.where(location: location,
                name: Faker::Name.name, 
                preferred_contact_method: contact_method,
-               email: contact_method&.field.downcase == "email" ? email : [nil, email].sample,
-               phone: contact_method&.field.downcase == "phone" ? phone : [nil, phone].sample,
+               email: contact_method&.field&.downcase == "email" ? email : [nil, email].sample,
+               phone: contact_method&.field&.downcase == "phone" ? phone : [nil, phone].sample,
                ).first_or_create!
 end
 
@@ -73,7 +73,7 @@ end
     offer.tag_list << tag
     offer.save!
   end
-end  
+end
 
 
 # matches

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -4,25 +4,22 @@ desc "Extra db functions: stats_check, reset db with seeds, import csv and seed 
 
 namespace :db do
 
-  task :rebuild_and_seed_dev => ['db:drop',
-                                 'db:create',
+  task :rebuild_and_seed_dev => ['db:reset',
                                  'db:migrate',
-                                 'db:seed',
                                  'db:import_all_seeds',
                                  'db:stats_check']
 
-  task :rebuild_and_seed => ['db:drop',
-                             'db:create',
+  task :rebuild_and_seed => ['db:reset',
                              'db:migrate',
                              'db:seed',
                              'db:stats_check']
 
   task :recreate_all_seeds => ['db:truncate_tables',
-                               'db:seed',
                                'db:import_all_seeds',
                                'db:stats_check']
 
-  task :import_all_seeds => ['db:import_dev_seeds',
+  task :import_all_seeds => ['db:seed',
+                             'db:import_dev_seeds',
                              'db:import_submission_response_seeds',
                              'db:import_user_seeds',
                              'db:import_custom_form_question_seeds',


### PR DESCRIPTION
## Why
Closes #719, since sometimes the seed would not perform successfully.

### Pre-Merge Checklist
- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [x] All outstanding questions and concerns have been resolved
- [x] Any next steps that seem like good ideas have been created as issues for future discussion & implementation
- [x] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [x] New features have been documented, and the code is understandable and well commented
- [x] Entry added to CHANGELOG.md if appropriate

## What and How
In favor of having consistent environments, I took the liberty to replace the sequence `db:drop db:create db:migrate` with `db:reset db:migrate`. This ensures consistency between environments and avoids running all the migrations (this could go bad easily). More notes in c69a95a.

Besides that, I also added `db:seed` to `import_all_seeds` to always seed the base, and then the development environment, which fixes the exception regarding an undefined method, and I added an `&` in case something else happens.

In the other hand, the bug mentioned at #719 regarding password length, I added a prefix, more notes at 9aecf92.

### Testing
Didn't add any testing for this.

## Next Steps
I see a lot of opportunities to improve the seed files, both structurally and in best practices. I would also advice to upgrade to Ruby 2.7.2 to avoid some warnings we're having.
