### PR TITLE
Fit all the offers in the initial view for the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ We're still in the [initial development phase](https://www.jering.tech/articles/
 This changelog also serves to acknowledge the incredible people who've contributed brilliance, effort and being. Their handles are listed under the first release they each  touched. 💗🙏🏾
 
 
+## [0.3.1] - 2020-10-10
+### Enhancement
+* Fit all the offers in the initial view for the map #774
+
 ## [0.3.0] - 2020-10-05
 ### Breaking changes
 * The `SMTP_ADDRESS` environment variable has been renamed to `SMTP_HOST` #750

--- a/app/javascript/pages/browse/MapBrowser.vue
+++ b/app/javascript/pages/browse/MapBrowser.vue
@@ -97,6 +97,7 @@
               },
             })
 
+            var bounds = new mapboxgl.LngLatBounds();
             geojson.features.forEach(function (marker) {
               var el = document.createElement('div');
               el.className = 'marker ' + marker.properties.contributionType.toLowerCase() + '-marker';
@@ -109,7 +110,9 @@
                 .setHTML('<h3>' + marker.properties.title + '</h3><p>' + marker.properties.categoryTag + '</p><p>' + marker.properties.description + '</p>'))
 
               newMarker.addTo(map)
+              bounds.extend(marker.geometry.coordinates);
             })
+            map.fitBounds(bounds, { padding: 50 });
           })
       },
       zoomend(map, e) {


### PR DESCRIPTION
## Why
Fixes #753, since the initial map view was not displaying all the offers.

### Pre-Merge Checklist

- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [x] All outstanding questions and concerns have been resolved
- [x] Any next steps that seem like good ideas have been created as issues for future discussion & implementation
- [x] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [x] New features have been documented, and the code is understandable and well commented
- [x] Entry added to CHANGELOG.md if appropriate

Regarding the CHANGELOG, not sure if I should do it. Please advice.

## What
- Uses bounds extender with processed markers in order to have all bounds and fit the map
- Uses padding to avoid cutting off the icons (see screenshot attached)

![image](https://user-images.githubusercontent.com/1270156/95659440-5b636900-0b21-11eb-9c33-49e77550674d.png)

## How
It uses [LngLatBounds](https://docs.mapbox.com/mapbox-gl-js/api/geography/#lnglatbounds) and it's method `extend` in order to have a bound box that later can be set to fit the map.

### Testing
N/A

## Next Steps
N/A

## Outstanding Questions, Concerns and Other Notes
- [x] Not sure if I should change the CHANGELOG myself.
- [x] I'm really worried about the performance of the `contributions_controller`. There are a lot of queries to the database that we should be able to either use a JOIN, an INCLUDES, etc.

### Accessibility
N/A

### Security
N/A

### Meta
N/A
