### PR TITLE
Start of css to be applied to all custom text (user submitted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ We're still in the [initial development phase](https://www.jering.tech/articles/
 
 This changelog also serves to acknowledge the incredible people who've contributed brilliance, effort and being. Their handles are listed under the first release they each  touched. 💗🙏🏾
 
+## [Unreleased]
+* Unordered lists in user provided custom text (eg /about) now display with discs ('bullets') #777, #779
 
 ## [0.3.0] - 2020-10-05
 ### Breaking changes

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,8 @@
 @import './yearbook';  // TODO: remove this once listings/new is refactored
 @import './listings';  // TODO: remove this once listings/new is refactored
 
+@import './custom_text';
+
 @import './mapbox-gl';
 @import './maps';
 

--- a/app/assets/stylesheets/custom_text.scss
+++ b/app/assets/stylesheets/custom_text.scss
@@ -1,0 +1,6 @@
+.custom-text {
+  // Bulma strips list-style from ol, ul by default
+  ul {
+    list-style: disc inside;
+  }
+}

--- a/app/javascript/pages/orientation/AboutSection.vue
+++ b/app/javascript/pages/orientation/AboutSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class='section'>
+  <div class='section custom-text'>
     <h2 class='subtitle'>{{title}}</h2>
     <p v-html="description" class='description'></p>
   </div>
@@ -8,8 +8,8 @@
 <script>
 export default {
   props:{
-    title:{type: String, default:"This is a placeholder!"},
-    description:{type: String, default:"Put descriptive things about this section here"}
+    title: {type: String, default: "This is a placeholder!"},
+    description: {type: String, default: "Put descriptive things about this section here"}
   },
 }
 </script>

--- a/app/views/contributions/thank_you.html.erb
+++ b/app/views/contributions/thank_you.html.erb
@@ -2,7 +2,7 @@
   <%= @current_organization&.name %>
 </div>
 
-<div class="header">
+<div class="header custom-text">
   <%= HtmlSanitizer.new(@system_setting.confirmation_page_text_header).sanitize_for_rails %>
 </div>
 
@@ -34,7 +34,7 @@
   </div>
 </div>
 
-<div class="footer">
+<div class="footer custom-text">
   <%= HtmlSanitizer.new(@system_setting.confirmation_page_text_footer).sanitize_for_rails %>
 </div>
 

--- a/app/views/public/about.html.erb
+++ b/app/views/public/about.html.erb
@@ -1,1 +1,3 @@
-<%= @about_us_text.present? ? @about_us_text : "Some more info about us..." %>
+<div class="custom-text">
+  <%= @about_us_text.present? ? @about_us_text : "Some more info about us..." %>
+</div>


### PR DESCRIPTION
## Why
Fixes #777, where unordered lists weren't rendering with discs in user-provided custom text.

Also sets up a container class for future styles that need to be applied to all custom text.

### Pre-Merge Checklist
- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation
- [x] New features have been documented, and the code is understandable and well commented
- [x] Entry added to CHANGELOG.md if appropriate

## What
Before:
![Screen Shot 2020-10-12 at 3 25 18 PM](https://user-images.githubusercontent.com/8330/95783361-a86d4980-0c9f-11eb-9eff-23fe54d5aa5c.png)

After:
![Screen Shot 2020-10-12 at 3 24 50 PM](https://user-images.githubusercontent.com/8330/95783373-af945780-0c9f-11eb-81e1-a119e7c07452.png)

## How
Introduced a new `custom_text.scss` file defining a `.custom-text` class.
This class needs to be applied to any element that contains user provided content.

## Outstanding Questions, Concerns and Other Notes
Could be worth considering what other styles we want to apply to custom text (eg, what about `ol`s?).

Co-authored-by: maebeale <meabeale@gmail.com>