### PR TITLE
Remove sanitize-for-vue

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -27,9 +27,11 @@ class PublicPagesController < PublicController
   end
 
   def landing_page
-    @landing_page_text_what = HtmlSanitizer.new(@system_setting.landing_page_text_what).sanitize_for_vue
-    @landing_page_text_who = HtmlSanitizer.new(@system_setting.landing_page_text_who).sanitize_for_vue
-    @landing_page_text_how = HtmlSanitizer.new(@system_setting.landing_page_text_how).sanitize_for_vue
-    @organization_name = Organization.current_organization.name
+    @json = {
+      landing_page_text_what: HtmlSanitizer.new(@system_setting.landing_page_text_what).sanitize,
+      landing_page_text_who: HtmlSanitizer.new(@system_setting.landing_page_text_who).sanitize,
+      landing_page_text_how: HtmlSanitizer.new(@system_setting.landing_page_text_how).sanitize,
+      organization_name: Organization.current_organization.name,
+    }.to_json
   end
 end

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -2,7 +2,7 @@ class PublicPagesController < PublicController
   layout :determine_layout
 
   def about
-    @about_us_text = HtmlSanitizer.new(@system_setting.about_us_text).sanitize_for_rails
+    @about_us_text = HtmlSanitizer.new(@system_setting.about_us_text).sanitize
   end
 
   def determine_layout

--- a/app/models/html_sanitizer.rb
+++ b/app/models/html_sanitizer.rb
@@ -19,8 +19,4 @@ class HtmlSanitizer
     safe_list_sanitizer.sanitize(@string,
                                  tags: self.class.tags, attributes: self.class.html_attributes).html_safe
   end
-
-  def sanitize_for_vue
-    sanitize_for_rails.gsub(/"/, "\\\"").gsub(/'/, "\\'").gsub(/[\r\n]+/, "\\\n").html_safe
-  end
 end

--- a/app/models/html_sanitizer.rb
+++ b/app/models/html_sanitizer.rb
@@ -13,7 +13,7 @@ class HtmlSanitizer
     @string = string
   end
 
-  def sanitize_for_rails
+  def sanitize
     return "" unless @string
     safe_list_sanitizer = Rails::Html::SafeListSanitizer.new
     safe_list_sanitizer.sanitize(@string,

--- a/app/views/contributions/thank_you.html.erb
+++ b/app/views/contributions/thank_you.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <div class="header custom-text">
-  <%= HtmlSanitizer.new(@system_setting.confirmation_page_text_header).sanitize_for_rails %>
+  <%= HtmlSanitizer.new(@system_setting.confirmation_page_text_header).sanitize %>
 </div>
 
 <hr>
@@ -35,6 +35,6 @@
 </div>
 
 <div class="footer custom-text">
-  <%= HtmlSanitizer.new(@system_setting.confirmation_page_text_footer).sanitize_for_rails %>
+  <%= HtmlSanitizer.new(@system_setting.confirmation_page_text_footer).sanitize %>
 </div>
 

--- a/app/views/public/landing_page.html.erb
+++ b/app/views/public/landing_page.html.erb
@@ -2,11 +2,6 @@
 
 <script>
   document.addEventListener('DOMContentLoaded', () => {
-    EntryPoints.orientation('#orientation', {
-      organization: "<%= @organization_name %>",
-      landing_page_text_what: "<%= @landing_page_text_what %>",
-      landing_page_text_who:  "<%= @landing_page_text_who %>",
-      landing_page_text_how:  "<%= @landing_page_text_how %>"
-    })
+    EntryPoints.orientation('#orientation', <%= raw @json %>)
   })
 </script>

--- a/spec/models/html_sanitizer_spec.rb
+++ b/spec/models/html_sanitizer_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe HtmlSanitizer, type: :model do
   let(:sanitizer) { described_class.new(string) }
   let(:partial_whitelist) { %w[b br h1 div span ol ul li] }
 
-  describe "#sanitize_for_rails" do
-    subject { sanitizer.sanitize_for_rails }
+  describe "#sanitize" do
+    subject { sanitizer.sanitize }
 
     let(:string) do
       %Q{


### PR DESCRIPTION
## Why
Found a bug with single-quotes in the custom regex we'd written and while looking into this, realized we probably don't need a separate sanitizer for vue. We were able to get the only current use of this method (on the landing page) to work with sanitize_for_rails along with regular serialization (.to_json).

### Pre-Merge Checklist
- [x] Security & accessibility have been considered
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation

## How
Refactored `HtmlSanitizer` class to drop `sanitize-for-vue` and rename `sanitize-for-rails` -> `sanitize`.

### Security
We're still running user content through `sanitize`. In fact, this is probably more secure now that we're not relying on a custom regex for sanitization.

Co-authored-by: maebeale <maebeale@gmail.com>