### PR TITLE
Show contributor name on Contributions page

### DIFF
--- a/app/javascript/pages/browse/ListBrowser.vue
+++ b/app/javascript/pages/browse/ListBrowser.vue
@@ -8,6 +8,7 @@
         <th>Service Area</th>
         <th>Connect</th>
         <th>Respond</th>
+        <th>Contributor Name</th>
 <!--        <th>Details</th>-->
       </tr>
       <tr v-for="contribution in contributions" :key="contribution.id">
@@ -30,6 +31,7 @@
         <td>
           <a :href="contribution.respond_path" class="button icon-list is-primary"><span class=""> Respond</span></a>
         </td>
+        <td>{{ contribution.name.match(/\((.*)\)/)[1] }}</td>
 <!--        <td>{{ contribution.title }}</td>-->
       </tr>
     </table>

--- a/app/javascript/pages/browse/TileListItem.vue
+++ b/app/javascript/pages/browse/TileListItem.vue
@@ -32,6 +32,9 @@
           <div v-if="service_area" class="has-text-grey-lighter">
             {{ service_area.name }}
           </div>
+          <div>
+            {{ `From: ${name.match(/\((.*)\)/)[1]}` }}
+          </div>
         </div>
       </div>
       <div class="actions">
@@ -65,7 +68,8 @@ export default {
     profile_path: String,
     respond_path: String,
     view_path: String,
-    match_path: String
+    match_path: String,
+    name: String
   },
   components: {
     TagList,


### PR DESCRIPTION
## Why
Shows contributor's name on the List and Tile views of the Contributions page (already shown on Map view).

https://github.com/rubyforgood/mutual-aid/issues/537

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [ ] All new features have been described in the pull request
- [ ] Security & accessibility have been considered
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation
- [ ] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [ ] New features have been documented, and the code is understandable and well commented
- [ ] Entry added to CHANGELOG.md if appropriate

## What
- [x] Displays Contributor name on Contributions list view
- [x] Displays Contributor name on Contributions tile view

<img width="1322" alt="Screenshot 2020-10-18 at 10 05 38" src="https://user-images.githubusercontent.com/14929975/96363233-e4366200-112a-11eb-9bba-1188100ad6ea.png">
<img width="299" alt="Screenshot 2020-10-18 at 10 12 38" src="https://user-images.githubusercontent.com/14929975/96363235-e6002580-112a-11eb-9991-4bf6799cd315.png">

## How
Contributor's name is stored as (Name) along with details of the offer in the name field. I've used a regex to match for text within brackets.

## Outstanding Questions, Concerns and Other Notes
I wasn't totally clear on the requirements - do we want the ability to Toggle showing contributor names as well?

If so, how would we want this to look on the page - would a toggle box belong alongside the Filters given that it's not a Filter but a display option?