### PR TITLE
Add fab class to fix whatsapp logo display

### DIFF
--- a/app/assets/stylesheets/font_awesome.scss
+++ b/app/assets/stylesheets/font_awesome.scss
@@ -5,3 +5,4 @@ $fa-font-path: '~@fortawesome/fontawesome-free/webfonts';
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
 @import '~@fortawesome/fontawesome-free/scss/solid';
 @import '~@fortawesome/fontawesome-free/scss/regular';
+@import '~@fortawesome/fontawesome-free/scss/brands';

--- a/app/javascript/components/MappedIconList.vue
+++ b/app/javascript/components/MappedIconList.vue
@@ -12,7 +12,7 @@ const iconNameMapping = {
   Email: 'envelope',
   Text: 'mobile-alt',
   Phone: 'phone',
-  WhatsApp: 'whatsapp',
+  WhatsApp: 'whatsapp fab',
   Call: 'phone',
   Ask: 'hand-sparkles',
   Offer: 'hand-holding-heart',

--- a/app/javascript/components/SingleIcon.vue
+++ b/app/javascript/components/SingleIcon.vue
@@ -10,7 +10,7 @@ const iconNameMapping = {
   Email: 'envelope',
   Text: 'mobile-alt',
   Phone: 'phone',
-  WhatsApp: 'whatsapp',
+  WhatsApp: 'whatsapp fab',
   Call: 'phone',
   Ask: 'hand-sparkles',
   Offer: 'hand-holding-heart',

--- a/spec/javascript/components/MappedIconList.spec.js
+++ b/spec/javascript/components/MappedIconList.spec.js
@@ -11,6 +11,6 @@ describe('MappedIconList', () => {
     assert.exists(wrapper.find('b-icon-stub[aria-label=Email][icon=envelope]').text())
     assert.exists(wrapper.find('b-icon-stub[aria-label=Text][icon=mobile-alt]').text())
     assert.exists(wrapper.find('b-icon-stub[aria-label=Call][icon=phone]').text())
-    assert.exists(wrapper.find('b-icon-stub[aria-label=WhatsApp][icon=whatsapp]').text())
+    assert.exists(wrapper.find('b-icon-stub[aria-label=WhatsApp][icon="whatsapp fab"]').text())
   })
 })

--- a/spec/javascript/components/MappedIconList.spec.js
+++ b/spec/javascript/components/MappedIconList.spec.js
@@ -6,10 +6,11 @@ describe('MappedIconList', () => {
   it('generally works', function() {
     const wrapper = shallowMount(MappedIconList, {
       localVue: configure(createLocalVue()),
-      propsData: { iconTypes: [{id: 1, name: "Email"}, {id: 2, name: "Text"},{id: 3, name: "Call"}]}
+      propsData: { iconTypes: [{id: 1, name: "Email"}, {id: 2, name: "Text"},{id: 3, name: "Call"},{id: 4, name: "WhatsApp"}]}
     })
     assert.exists(wrapper.find('b-icon-stub[aria-label=Email][icon=envelope]').text())
     assert.exists(wrapper.find('b-icon-stub[aria-label=Text][icon=mobile-alt]').text())
     assert.exists(wrapper.find('b-icon-stub[aria-label=Call][icon=phone]').text())
+    assert.exists(wrapper.find('b-icon-stub[aria-label=WhatsApp][icon=whatsapp]').text())
   })
 })


### PR DESCRIPTION
Co-authored-by: Leah Riffell <leah.riffell@gmail.com>
Co-authored-by: Angela Guardia <47278429+AngelaGuardia@users.noreply.github.com>
Co-authored-by: David Atkins <atki1080@gmail.com>
Co-authored-by: Taylor Phillips <taylorscottphillips@gmail.com>
Co-authored-by: Nathan Darrington <npdarrington@icloud.com>
Co-authored-by: Eugene Theriault <hybridbassist@gmail.com>
Co-authored-by: Will Dunlap <dunlapww@gmail.com>

## Why
closes #391 

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [X] All new features have been described in the pull request
- [ ] ~Security & accessibility have been considered~
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation
- [X] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [ ] ~New features have been documented, and the code is understandable and well commented~
- [ ] ~Entry added to CHANGELOG.md if appropriate~

## What
Add fab class to fix whatsapp logo display
Icon now works both on the Vue side (/contributions), and on the rails side (/contact_methods)

## How
Font awesome requires fab class to display brand icons
Imported font awesome brand
Added fab class to the whatsapp icon of SingleIcon.vue and MappedIconList.vue

### Testing
Added a test that whatsapp label exists and fab class exists

## Outstanding Questions, Concerns and Other Notes