### PR TITLE
Allow anonymous users to generate CommunicationLogs

### DIFF
--- a/app/interactions/email_new_submission.rb
+++ b/app/interactions/email_new_submission.rb
@@ -2,7 +2,7 @@
 
 class EmailNewSubmission < ActiveInteraction::Base
   object :submission
-  object :user
+  object :user, default: nil
 
   def execute
     email = SubmissionMailer.new_submission_confirmation_email(submission)

--- a/app/models/communication_log.rb
+++ b/app/models/communication_log.rb
@@ -40,7 +40,7 @@ end
 #  subject            :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  created_by_id      :bigint           default(1), not null
+#  created_by_id      :bigint
 #  delivery_method_id :bigint           not null
 #  match_id           :bigint
 #  person_id          :bigint

--- a/db/migrate/20201113172851_allow_null_communication_logs_created_by_id.rb
+++ b/db/migrate/20201113172851_allow_null_communication_logs_created_by_id.rb
@@ -1,0 +1,5 @@
+class AllowNullCommunicationLogsCreatedById < ActiveRecord::Migration[6.0]
+  def change
+    change_column :communication_logs, :created_by_id, :bigint, default: nil, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_06_172102) do
+ActiveRecord::Schema.define(version: 2020_11_13_172851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 2020_09_06_172102) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "delivery_status"
     t.string "subject"
-    t.bigint "created_by_id", default: 1, null: false
+    t.bigint "created_by_id"
     t.string "body"
     t.boolean "outbound", default: true, null: false
     t.bigint "delivery_method_id", null: false

--- a/spec/interactions/email_new_submission_spec.rb
+++ b/spec/interactions/email_new_submission_spec.rb
@@ -41,4 +41,13 @@ RSpec.describe EmailNewSubmission do
       expect(last_log.delivery_status).to eq 'error'
     end
   end
+
+  context 'when submission is initiated by anonymous user' do
+    let(:user) { nil }
+
+    it 'records a log with nil user' do
+      expect { interaction }.to change(CommunicationLog, :count).by(1)
+      expect(CommunicationLog.last.created_by).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Why
Fixes #805.

Integrating `EmailNewSubmission` into `Asks|OffersController` broke those forms for anonymous users. `CommunicationLog.log_email` allows a nil `initiator` object but the DB does not allow null in the corresponding `created_by_id` column.

## Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] All new features have been described in the pull request
- [x] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [x] All outstanding questions and concerns have been resolved
- [x] Any next steps that seem like good ideas have been created as issues for future discussion & implementation

## How
First, the `EmailNewSubmission` interactor needed to allow a nil user (for when `current_user` is `nil`). But this by itself was not sufficient because the nil then causes `PG:NotNullViolation`.

`communication_logs.created_by_id` did have a default id set to 1, but this requires persistence code to omit the `created_by` field if it isn't provided; if a write is issued containing `created_by: nil`, rails will pass that on to the DB which then rejects it.

Moreover, i don't think it's wise to assume our 'system user' will always have an id of 1. If we really want CommunicationLog entries to have a system user as their default user id, we should explicitly set this in code.

Instead of implementing this additional logic, i've chosen here to drop the default value and changed the column to be nullable. As such, `null` can represent the same semantics of defaulting to the system user.

## Testing
- [x] Tests forthcoming

## Outstanding Questions, Concerns and Other Notes
Would love your eyes on this @maebeale, particularly around the question of defaulting `created_by_id` to 1.
