### PR TITLE
View contributions publicly when peer-to-peer is on

### DIFF
--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -8,8 +8,8 @@ class ContributionsController < ApplicationController
 
   def index
     @filter_types = FilterTypeBlueprint.render([ContributionType, Category, ServiceArea, UrgencyLevel, ContactMethod])
-    filter = BrowseFilter.new(filter_params, self)
-    @contributions = ContributionBlueprint.render(filter.contributions, **filter.options)
+    filter = BrowseFilter.new(filter_params)
+    @contributions = ContributionBlueprint.render(filter.contributions, contribution_blueprint_options)
     respond_to do |format|
       format.html
       format.json { render inline: @contributions }
@@ -57,6 +57,13 @@ class ContributionsController < ApplicationController
   end
 
   private
+
+
+  def contribution_blueprint_options
+    options = { respond_path: ->(id) { respond_contribution_path(id)} }
+    options[:view_path] = ->(id) { contribution_path(id) } if SystemSetting.current_settings&.peer_to_peer?
+    options
+  end
 
   def filter_params
     return Hash.new unless allowed_params && allowed_params.to_h.any?

--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ContributionsController < ApplicationController
-  before_action :authenticate_user!, except: %i[combined_form respond thank_you]
+  before_action :authenticate_user!, unless: :peer_to_peer_mode?
   before_action :set_contribution, only: %i[respond triage]
 
   layout 'without_navbar', only: [:thank_you]
@@ -58,6 +58,9 @@ class ContributionsController < ApplicationController
 
   private
 
+  def peer_to_peer_mode?
+    @system_setting.peer_to_peer?
+  end
 
   def contribution_blueprint_options
     options = { respond_path: ->(id) { respond_contribution_path(id)} }

--- a/app/models/browse_filter.rb
+++ b/app/models/browse_filter.rb
@@ -23,11 +23,10 @@ class BrowseFilter
   end.freeze
   ALLOWED_MODEL_NAMES = ['Ask', 'Offer'].freeze
 
-  attr_reader :parameters, :context
+  attr_reader :parameters
 
-  def initialize(parameters, context = nil)
+  def initialize(parameters)
     @parameters = parameters
-    @context = context
   end
 
   def contributions
@@ -36,14 +35,6 @@ class BrowseFilter
       models = ContributionType.where(name: model_names.intersection(ALLOWED_MODEL_NAMES)).map(&:model)
       models.map { |model| filter(model) }.flatten
     end
-  end
-
-  def options
-    return {} unless context
-
-    options = { respond_path: ->(id) { context.respond_contribution_path(id)} }
-    options[:view_path] = ->(id) { context.contribution_path(id) } if SystemSetting.current_settings&.peer_to_peer?
-    options
   end
 
   private

--- a/spec/requests/contributions_spec.rb
+++ b/spec/requests/contributions_spec.rb
@@ -13,12 +13,11 @@ RSpec.describe '/contributions', type: :request do
       location_attributes: { zip: '12e45' },
   }}
 
-  before { sign_in create(:user) }
+  let(:user) { create(:user) }
 
   ['when logged in', 'when logged out but p2p is enabled'].each do |scenario|
     describe scenario do
       before do
-        user = create(:user)
         sign_in user unless scenario =~ /logged out/
         allow_any_instance_of(SystemSetting).to receive(:peer_to_peer?).and_return(true) if scenario =~ /p2p is enabled/
       end
@@ -83,6 +82,20 @@ RSpec.describe '/contributions', type: :request do
 
           expect(response).to be_successful
         end
+      end
+    end
+  end
+
+  describe 'when logged out and p2p is disabled' do
+    describe 'GET /index' do
+      before do
+        allow_any_instance_of(SystemSetting).to receive(:peer_to_peer?).and_return(false)
+      end
+
+      it 'redirects to the user login page' do
+        create(:listing)
+        get contributions_url
+        assert_redirected_to new_user_session_url
       end
     end
   end

--- a/spec/requests/contributions_spec.rb
+++ b/spec/requests/contributions_spec.rb
@@ -15,65 +15,75 @@ RSpec.describe '/contributions', type: :request do
 
   before { sign_in create(:user) }
 
-  describe 'GET /index' do
-    it 'renders a successful response' do
-      create(:listing)
-      get contributions_url
-      expect(response).to be_successful
-    end
+  ['when logged in', 'when logged out but p2p is enabled'].each do |scenario|
+    describe scenario do
+      before do
+        user = create(:user)
+        sign_in user unless scenario =~ /logged out/
+        allow_any_instance_of(SystemSetting).to receive(:peer_to_peer?).and_return(true) if scenario =~ /p2p is enabled/
+      end
 
-    it 'allows asking for a specific subtype of listing' do
-      ask = create(:ask, title: 'this is the ask title')
-      offer = create(:offer, title: 'this is the offer title')
-      get contributions_url, params: { ContributionType: { 'Ask' => 1 } }
-      expect(response.body).to match(ask.title)
-      expect(response.body).not_to match(offer.title)
-      get contributions_url, params: { ContributionType: { 'Offer' => 1 } }
-      expect(response.body).not_to match(ask.title)
-      expect(response.body).to match(offer.title)
-      get contributions_url, params: { ContributionType: { 'Ask' => 1, 'Offer' => 1 } }
-      expect(response.body).to match(ask.title)
-      expect(response.body).to match(offer.title)
-    end
+      describe 'GET /index' do
+        it 'renders a successful response' do
+          create(:listing)
+          get contributions_url
+          expect(response).to be_successful
+        end
 
-    it 'parses requests for a filtered list' do
-      categories = [
-        create(:category, name: Faker::Lorem.word),
-        create(:category, name: Faker::Lorem.word)
-      ]
-      both_tags_listing = create(:listing, tag_list: categories.map(&:name))
-      expected_area = both_tags_listing.service_area
-      expected_area.name = Faker::Address.community
-      expected_area.save!
-      one_tag_listing = create(:listing, service_area: expected_area, tag_list: categories.sample.name)
-      both_tags_wrong_area_listing = create(:listing, tag_list: categories.map(&:name))
-      no_tags_correct_area_listing = create(:listing, service_area: expected_area)
+        it 'allows asking for a specific subtype of listing' do
+          ask = create(:ask, title: 'this is the ask title')
+          offer = create(:offer, title: 'this is the offer title')
+          get contributions_url, params: { ContributionType: { 'Ask' => 1 } }
+          expect(response.body).to match(ask.title)
+          expect(response.body).not_to match(offer.title)
+          get contributions_url, params: { ContributionType: { 'Offer' => 1 } }
+          expect(response.body).not_to match(ask.title)
+          expect(response.body).to match(offer.title)
+          get contributions_url, params: { ContributionType: { 'Ask' => 1, 'Offer' => 1 } }
+          expect(response.body).to match(ask.title)
+          expect(response.body).to match(offer.title)
+        end
 
-      # passing `as: json` to `get` does some surprising things to the request and its params that would break this test
-      get contributions_url, {
-        params: { "Category[#{categories[0].id}]": 1, "Category[#{categories[1].id}]": 1, "ServiceArea[#{expected_area.id}]": 1 },
-        headers: { 'HTTP_ACCEPT' => 'application/json' }
-      }
+        it 'parses requests for a filtered list' do
+          categories = [
+            create(:category, name: Faker::Lorem.word),
+            create(:category, name: Faker::Lorem.word)
+          ]
+          both_tags_listing = create(:listing, tag_list: categories.map(&:name))
+          expected_area = both_tags_listing.service_area
+          expected_area.name = Faker::Address.community
+          expected_area.save!
+          one_tag_listing = create(:listing, service_area: expected_area, tag_list: categories.sample.name)
+          both_tags_wrong_area_listing = create(:listing, tag_list: categories.map(&:name))
+          no_tags_correct_area_listing = create(:listing, service_area: expected_area)
 
-      expect(response.body).to match(/#{expected_area.name.to_json}/)
+          # passing `as: json` to `get` does some surprising things to the request and its params that would break this test
+          get contributions_url, {
+            params: { "Category[#{categories[0].id}]": 1, "Category[#{categories[1].id}]": 1, "ServiceArea[#{expected_area.id}]": 1 },
+            headers: { 'HTTP_ACCEPT' => 'application/json' }
+          }
 
-      response_ids = JSON.parse(response.body).map { |hash| hash['id']}
-      expect(response_ids).to include(both_tags_listing.id)
-      expect(response_ids).to include(one_tag_listing.id)
-      expect(response_ids).not_to include(both_tags_wrong_area_listing.id)
-      expect(response_ids).not_to include(no_tags_correct_area_listing.id)
-    end
-  end
+          expect(response.body).to match(/#{expected_area.name.to_json}/)
 
-  describe 'GET /contributions/:id' do
-    it 'is successful' do
-      contribution = create(:listing)
+          response_ids = JSON.parse(response.body).map { |hash| hash['id']}
+          expect(response_ids).to include(both_tags_listing.id)
+          expect(response_ids).to include(one_tag_listing.id)
+          expect(response_ids).not_to include(both_tags_wrong_area_listing.id)
+          expect(response_ids).not_to include(no_tags_correct_area_listing.id)
+        end
+      end
 
-      get(
-        contribution_url(contribution),
-      )
+      describe 'GET /contributions/:id' do
+        it 'is successful' do
+          contribution = create(:listing)
 
-      expect(response).to be_successful
+          get(
+            contribution_url(contribution),
+          )
+
+          expect(response).to be_successful
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Why
 
This is one of the required steps of the peer-to-peer matchmaking workflow. This makes the list of available contributions generally public if the peer-to-peer setting is on.
<!--
A summary of what problem this pull request is trying to solve. Include a #reference to an existing issue, which should provide a more detailed explanation of the problem, as well as any discussion about the nature of the problem.

If appropriate, use github's [issue linking keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to automatically close any issues that this pull request resolves.
-->

## Next Steps
<!--
This section is to highlight any ideas you have for how this feature could be extended in the future.

You should also consider adding issues for these next steps
-->

The next step after this will be to change what the "Respond" button does for people who aren't logged in. I'd prefer to keep that next step in a separate PR, but can add it on to here if people would rather keep them together.

Also, the permission logic here should be refactored out to a Pundit object once we're bringing those in. @maebeale talked about adding features later that allow users to mark their contributions as "for admin eyes only" or something similar. Implementation of those features would be a good time to refactor here.

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [ ] All outstanding questions and concerns have been resolved
- [x] Any next steps that seem like good ideas have been created as issues for future discussion & implementation
- [x] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [x] New features have been documented, and the code is understandable and well commented
- [ ] Entry added to CHANGELOG.md if appropriate

## What
<!--
A list of the changes included in this pull request. A checkbox list is probably a good choice here, and the boxes should be checked off as tasks are completed. This section may be omitted if the Why section provides enough information and only a few changes were made (eg, for simple bug reports).

Always highlight breaking changes or any changes that effect the behaviour of user facing components of the application

- [ ] Put your changes in a list like this
- [x] Then you can check them off like this!


Also, include screenshots if you can!
-->
- [x] moved the code that generates the urls for the response buttons out of the presenter and into the controller
- [x] updated controller before actions for authentication to include the new logic
- [x] refactored tests to describe the new behavior
- [ ] TODO: changed the `ContributionsController#respond` action because the view for that page currently has a lot of stuff in it that we don't want publicly-facing



### Accessibility
<!--
If this change will make any significant changes to either physical accessibility (eg, making the website work better with screenreaders) or technical accessibility (eg, making the website load faster for people with marginal internet), you should explain what they are, and highlight any issues or concerns you might have that haven't been resolved.
-->
I expect this change will have no net effect on accessibility excepting any of the security concerns below.

### Security
<!--
Address how this change will improve/lessen the security of the application - for example, it improves HTML sanitization or opens a new attack surface. Always explain so that developers without a security background can understand. Similarly, address how this change will impact the accessibility of the application. Be sure to address both physical accessibility (eg, making the website work better with screenreaders) and technical accessibility (eg, making the website load faster for people with marginal internet). If you're not sure what to put here, don't worry! Just explain what you can, and make sure to note that you think this issue needs to be reviewed with security & accessibility in mind
-->

There is a security risk here of inadvertently allowing information to be public.

- It is possible that someone will try submit some form of spam, advertising, or inappropriate promotion if info from the contribution forms is automatically made public like this
- It is very likely that some user will not understand what information on the forms they fill will or won't be made public
- It is possible take information that a user wants to and expects will stay private and make it public later. This can happen if an admin changes to p2p mode without notifying users
- an admin could also reveal info by changing the setting by accident

I feel like it's acceptable to continue with this work, understanding that the above security concerns are things we can address once we confirm mutual aid groups are happy with the basic functionality

