### PR TITLE
Restore ability to hit /thank_you page w/o logging in

### DIFF
--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ContributionsController < ApplicationController
-  before_action :authenticate_user!, unless: :peer_to_peer_mode?
+  before_action :authenticate_user!, except: %i[thank_you], unless: :peer_to_peer_mode?
   before_action :set_contribution, only: %i[respond triage]
 
   layout 'without_navbar', only: [:thank_you]


### PR DESCRIPTION
Was mistakenly dropped in e301ccd9, but is necessary even in dispatch mode so that guests can create contributions.


https://user-images.githubusercontent.com/8330/104955888-f7aad080-5998-11eb-9b62-1a3986e3c4d0.mov

