### PR TITLE
Hide the "respond" UI items when not logged in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This changelog also serves to acknowledge the incredible people who've contribut
 * Allow custom text on landing page to override default text #769, #780
 * Add Rubocop #793
 * Show the "Contributions" link in the navbar for P2P users even if they aren't logged in
+* Hide the respond button on contributions when nobody is logged in. (We'll add more functionality later for the peer-to-peer scneario) #819
 
 ## [0.3.1] - 2020-10-10
 ### Enhancement

--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -70,9 +70,10 @@ class ContributionsController < ApplicationController
   end
 
   def filter_params
-    return Hash.new unless allowed_params && allowed_params.to_h.any?
+    return {} unless allowed_params&.to_h.any?
+
     allowed_params.to_h.filter { |key, _v| BrowseFilter::ALLOWED_PARAMS.keys.include? key}.tap do |hash|
-      hash.keys.each { |key| hash[key] = hash[key].keys}
+      hash.each_key { |key| hash[key] = hash[key].keys}
     end
   end
 

--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -63,7 +63,8 @@ class ContributionsController < ApplicationController
   end
 
   def contribution_blueprint_options
-    options = { respond_path: ->(id) { respond_contribution_path(id)} }
+    options = {}
+    options[:respond_path] = ->(id) { respond_contribution_path(id)} if current_user
     options[:view_path] = ->(id) { contribution_path(id) } if SystemSetting.current_settings.peer_to_peer?
     options
   end

--- a/app/javascript/pages/browse/ListBrowser.vue
+++ b/app/javascript/pages/browse/ListBrowser.vue
@@ -55,7 +55,7 @@ export default {
   },
   computed: {
     showRespondColumn() {
-      return !!this.contributions.find( contribution => !!contribution.respond_path)
+      return this.contributions.some( contribution => contribution.respond_path)
     }
   },
 }

--- a/app/javascript/pages/browse/ListBrowser.vue
+++ b/app/javascript/pages/browse/ListBrowser.vue
@@ -7,7 +7,7 @@
         <th>Urgency</th>
         <th>Service Area</th>
         <th>Connect</th>
-        <th>Respond</th>
+        <th><span v-if="showRespondColumn">Respond</span></th>
 <!--        <th>Details</th>-->
       </tr>
       <tr v-for="contribution in contributions" :key="contribution.id">
@@ -28,7 +28,9 @@
           <SingleIcon :iconType="contribution.contact_types[0].name" />
         </td>
         <td>
-          <a :href="contribution.respond_path" class="button icon-list is-primary"><span class=""> Respond</span></a>
+          <div v-if="contribution.respond_path">
+            <a :href="contribution.respond_path" class="button icon-list is-primary"><span class=""> Respond</span></a>
+          </div>
         </td>
 <!--        <td>{{ contribution.title }}</td>-->
       </tr>
@@ -52,12 +54,9 @@ export default {
     MappedIconList,
   },
   computed: {
-    showUrgentIcon() {
-      return !(this.urgency && this.urgency.id > 1)
-    },
-    urgencyColor() {
-      return this.showUrgentIcon ? 'is-warning' : 'is-light is-warning'
-    },
+    showRespondColumn() {
+      return !!this.contributions.find( contribution => !!contribution.respond_path)
+    }
   },
 }
 </script>

--- a/lib/contributions.json
+++ b/lib/contributions.json
@@ -1,97 +1,166 @@
 {
-  "_comment": "This is useful seed data. It could go into `spec/fixtures` at some point. For now, we're using it as examples to develop against, so I've put it in `lib`",
-  "contributions": [
-    {
-      "id": 1,
-      "contribution_type": {"id": 1, "name": "ask"},
-      "category_tags": [{"id": 1, "name": "Care"}],
-      "availability": [
-        {"id": 1, "name": "AM"},
-        {"id": 2, "name": "PM"},
-        {"id": 3, "name": "EVE"}
-      ],
-      "urgency": {"id": 1, "name": "Within 1-2 days"},
-      "publish_until": "2021-10-11",
-      "publish_until_humanized": "this year",
-      "created_at": "2020-04-11T02:15:50.499Z",
-      "service_area": {"id": 1, "name": "East Bay"},
-      "map_location": "44.5,-85.1",
-      "title": "Look after my kid",
-      "description": "Lorem Ipsum is the name of my child. They are a very nice child. You won't have much trouble, but they are young and need the help",
-      "contact_types": [{"id": 1, "name": "text"}]
+  "_comment": "This is useful seed data copied from a development environment. Feel free to update it as the API changes.",
+  "_commentTODO": "TODO: move into the spec folder",
+  "contributions": [{
+    "id": 6,
+    "category_tags": [{
+        "id": 14,
+        "name": "accessing healthcare"
+    }],
+    "contact_types": [{
+        "id": 3,
+        "name": "Email"
+    }],
+    "contribution_type": "Offer",
+    "created_at": 1607039850483.441,
+    "description": null,
+    "inexhaustible": false,
+    "location": null,
+    "match_path": null,
+    "name": "Offer: accessing healthcare (Dr. Jill Koss)",
+    "profile_path": null,
+    "respond_path": "/contributions/3/respond?locale=en",
+    "service_area": {
+        "id": 6,
+        "description": null,
+        "location": {
+            "id": 6,
+            "city": null,
+            "county": null,
+            "neighborhood": null,
+            "region": null,
+            "state": null,
+            "street_address": null,
+            "zip": null
+        },
+        "name": "University Acres"
     },
-    {
-      "id": 2,
-      "category_tags": [
-        {"id": 1, "name": "Care"},
-        {"id": 2, "name": "Meals"}
-      ],
-      "availability": [
-        {"id": 1, "name": "AM"},
-        {"id": 2, "name": "PM"},
-        {"id": 3, "name": "EVE"}
-      ],
-      "urgency": {"id": 3, "name": "Any Time"},
-      "publish_until": "2021-01-01",
-      "publish_until_humanized": "this week",
-      "service_area": null,
-      "map_location": null,
-      "contribution_type": {"id": 4, "name": "community resource"},
-      "contact_types": [
-        {"id": 2, "name": "call"},
-        {"id": 3, "name": "email"}
-      ]
+    "title": null,
+    "urgency": {
+        "id": 1,
+        "name": "Within 1-2 days"
     },
-    {
-      "id": 3,
-      "category_tags": [{"id": 3, "name": "Housework"}],
-      "availability": [{"id": 3, "name": "EVE"}],
-      "urgency": {"id": 3, "name": "I can wait a week"},
-      "created_at": "2020-04-11T04:17:31.288Z",
-      "publish_until": "2021-09-11",
-      "service_area": {"id": 1, "name": "East Bay"},
-      "contribution_type": {"id": 4, "name": "ask"},
-      "title": "bathroom help, like cleaning specifically if that's okay",
-      "description": "I'm afraid I'll fall and hurt my hip again. Can someone help me clean?",
-      "contact_types": [
-        {"id": 2, "name": "call"},
-        {"id": 3, "name": "email"}
-      ]
+    "view_path": "/contributions/6?locale=en"
+}, {
+    "id": 7,
+    "category_tags": [{
+        "id": 10,
+        "name": "services"
+    }],
+    "contact_types": [{
+        "id": 1,
+        "name": "Call"
+    }],
+    "contribution_type": "Offer",
+    "created_at": 1607039850532.4119,
+    "description": null,
+    "inexhaustible": false,
+    "location": null,
+    "match_path": null,
+    "name": "Offer: services (Romeo Leannon)",
+    "profile_path": null,
+    "respond_path": "/contributions/4/respond?locale=en",
+    "service_area": {
+        "id": 3,
+        "description": null,
+        "location": {
+            "id": 3,
+            "city": null,
+            "county": null,
+            "neighborhood": null,
+            "region": null,
+            "state": null,
+            "street_address": null,
+            "zip": null
+        },
+        "name": "Eagle Estates"
     },
-    {
-      "id": 4,
-      "category_tags": [{"id": 3, "name": "Housework"}],
-      "availability": [{"id": 3, "name": "EVE"}],
-      "urgency": {"id": 3, "name": "I can wait a week"},
-      "created_at": "2020-04-11T04:17:31.288Z",
-      "publish_until": "2021-09-11",
-      "service_area": {"id": 1, "name": "East Bay"},
-      "contribution_type": {"id": 4, "name": "ask"},
-      "title": "bathroom help, like cleaning specifically if that's okay",
-      "description": "I'm afraid I'll fall and hurt my hip again. Can someone help me clean?",
-      "contact_types": [
-        {"id": 2, "name": "call"},
-        {"id": 3, "name": "email"}
-      ]
+    "title": null,
+    "urgency": {
+        "id": 4,
+        "name": "Anytime"
     },
-    {
-      "id": 5,
-      "contribution_type": {"id": 1, "name": "ask"},
-      "category_tags": [{"id": 1, "name": "Care"}],
-      "availability": [
-        {"id": 1, "name": "AM"},
-        {"id": 2, "name": "PM"},
-        {"id": 3, "name": "EVE"}
-      ],
-      "urgency": {"id": 1, "name": "Within 1-2 days"},
-      "publish_until": "2021-10-11",
-      "publish_until_humanized": "this year",
-      "created_at": "2020-04-11T02:15:50.499Z",
-      "service_area": {"id": 1, "name": "East Bay"},
-      "map_location": "44.5,-85.1",
-      "title": "Look after my kid",
-      "description": "Lorem Ipsum is the name of my child. They are a very nice child. You won't have much trouble, but they are young and need the help",
-      "contact_types": [{"id": 1, "name": "text"}]
-    }
+    "view_path": "/contributions/7?locale=en"
+}, {
+    "id": 8,
+    "category_tags": [{
+        "id": 23,
+        "name": "emotional"
+    }],
+    "contact_types": [{
+        "id": 1,
+        "name": "Call"
+    }],
+    "contribution_type": "Offer",
+    "created_at": 1607039850580.138,
+    "description": null,
+    "inexhaustible": false,
+    "location": null,
+    "match_path": null,
+    "name": "Offer: emotional (Romeo Leannon)",
+    "profile_path": null,
+    "respond_path": "/contributions/5/respond?locale=en",
+    "service_area": {
+        "id": 2,
+        "description": null,
+        "location": {
+            "id": 2,
+            "city": null,
+            "county": null,
+            "neighborhood": null,
+            "region": null,
+            "state": null,
+            "street_address": null,
+            "zip": null
+        },
+        "name": "Eagle Court"
+    },
+    "title": null,
+    "urgency": {
+        "id": 1,
+        "name": "Within 1-2 days"
+    },
+    "view_path": "/contributions/8?locale=en"
+}, {
+    "id": 9,
+    "category_tags": [{
+        "id": 11,
+        "name": "tech support"
+    }],
+    "contact_types": [{
+        "id": 1,
+        "name": "Call"
+    }],
+    "contribution_type": "Offer",
+    "created_at": 1607039850634.96,
+    "description": null,
+    "inexhaustible": false,
+    "location": null,
+    "match_path": null,
+    "name": "Offer: tech support (Romeo Leannon)",
+    "profile_path": null,
+    "respond_path": "/contributions/6/respond?locale=en",
+    "service_area": {
+        "id": 4,
+        "description": null,
+        "location": {
+            "id": 4,
+            "city": null,
+            "county": null,
+            "neighborhood": null,
+            "region": null,
+            "state": null,
+            "street_address": null,
+            "zip": null
+        },
+        "name": "Park Village"
+    },
+    "title": null,
+    "urgency": {
+        "id": 1,
+        "name": "Within 1-2 days"
+    },
+    "view_path": "/contributions/9?locale=en"
+}
   ]
 }

--- a/spec/javascript/pages/browse/ListBrowser.spec.js
+++ b/spec/javascript/pages/browse/ListBrowser.spec.js
@@ -4,21 +4,33 @@ import ListBrowser from 'pages/browse/ListBrowser'
 import testData  from '../../../../lib/contributions.json'
 
 describe('ListBrowser', () => {
-  it('shows the respond column with typical data', function () {
-    const wrapper = shallowMount(ListBrowser, {
+  def('contributions', testData)
+
+  def('wrapper', () => {
+    return shallowMount(ListBrowser, {
       localVue: configure(createLocalVue()),
-      propsData: testData
+      propsData: $contributions,
     })
-    var respondHeaders = wrapper.findAll('th').filter( header => header.text() == 'Respond')
-    assert.equal(1, respondHeaders.length)
   })
-  it('hides the respond if there is no response urls', function() {
-    var responselessContributions = testData.contributions.map( contribution => { contribution.respond_path = ''; return contribution})
-    const wrapper = shallowMount(ListBrowser, {
-      localVue: configure(createLocalVue()),
-      propsData: {responselessContributions}
+
+  def('tableHeaders', () => $wrapper.findAll('th').wrappers)
+
+  describe('respond column', () => {
+    it('shows the column with typical data', function () {
+      assert.isTrue($tableHeaders.some(header => header.text() == 'Respond'))
     })
-    var respondHeaders = wrapper.findAll('th').filter( header => header.text() == 'Respond')
-    assert.equal(0, respondHeaders.length)
+
+    describe('when contributions do not come with response urls', () => {
+      def('contributions', () => {
+        testData.contributions.map(contribution => {
+          contribution.respond_path = ''
+          return contribution
+        })
+      })
+
+      it('hides the respond button', function() {
+        assert.isFalse($tableHeaders.some(header => header.text() == 'Respond'))
+      })
+    })
   })
 })

--- a/spec/javascript/pages/browse/ListBrowser.spec.js
+++ b/spec/javascript/pages/browse/ListBrowser.spec.js
@@ -1,16 +1,24 @@
-import {assert} from 'chai'
-import {mount} from '@vue/test-utils'
+import {createLocalVue, shallowMount} from '@vue/test-utils'
+import {configure} from 'vue_config'
 import ListBrowser from 'pages/browse/ListBrowser'
-import testData from '../../../../lib/contributions.json'
+import testData  from '../../../../lib/contributions.json'
 
 describe('ListBrowser', () => {
-  it('works with reasonable data', function () {
-    // TODO - get this working again!!!
-    // const wrapper = mount(ListBrowser, {
-    //   propsData: {
-    //     contributions: testData.contributions,
-    //   },
-    // })
-    // assert.match(wrapper.text(), /look after my kid/i)
+  it('shows the respond column with typical data', function () {
+    const wrapper = shallowMount(ListBrowser, {
+      localVue: configure(createLocalVue()),
+      propsData: testData
+    })
+    var respondHeaders = wrapper.findAll('th').filter( header => header.text() == 'Respond')
+    assert.equal(1, respondHeaders.length)
+  })
+  it('hides the respond if there is no response urls', function() {
+    var responselessContributions = testData.contributions.map( contribution => { contribution.respond_path = ''; return contribution})
+    const wrapper = shallowMount(ListBrowser, {
+      localVue: configure(createLocalVue()),
+      propsData: {responselessContributions}
+    })
+    var respondHeaders = wrapper.findAll('th').filter( header => header.text() == 'Respond')
+    assert.equal(0, respondHeaders.length)
   })
 })

--- a/spec/javascript/pages/browse/ListBrowser.spec.js
+++ b/spec/javascript/pages/browse/ListBrowser.spec.js
@@ -1,7 +1,7 @@
 import {createLocalVue, shallowMount} from '@vue/test-utils'
 import {configure} from 'vue_config'
 import ListBrowser from 'pages/browse/ListBrowser'
-import testData  from '../../../../lib/contributions.json'
+import testData from '../../../../lib/contributions.json'
 
 describe('ListBrowser', () => {
   def('contributions', testData)

--- a/spec/requests/contributions_spec.rb
+++ b/spec/requests/contributions_spec.rb
@@ -27,7 +27,13 @@ RSpec.describe '/contributions', type: :request do
         expect(response).to be_successful
       end
 
-      it 'is shows a contribution response page' do
+      it 'includes a link to respond to the contribution' do
+        listing = create(:listing)
+        get contributions_url
+        expect(response.body).to match(/#{respond_contribution_path(listing.id)}/)
+      end
+
+      it 'shows a contribution response page' do
         contribution = create(:listing)
         get contribution_url(contribution)
         expect(response).to be_successful
@@ -45,14 +51,12 @@ RSpec.describe '/contributions', type: :request do
         expect(response).to be_successful
       end
 
-      # # This test is commented out because it probably should redirect to
-      # # a page that's different than would dispatchers etc. see
-      #
-      # it 'is shows a contribution response page' do
-      #   contribution = create(:listing)
-      #   get contribution_url(contribution)
-      #   expect(response).to be_successful
-      # end
+      # TODO: change this behavior once Pundit is more thoroughly set up
+      it 'has no link to respond to the contribution' do
+        listing = create(:listing)
+        get contributions_url
+        expect(response.body).to_not match(/#{respond_contribution_path(listing.id)}/)
+      end
     end
 
     describe 'when logged out and p2p is disabled' do


### PR DESCRIPTION
## Why
This addresses one of the items in #819

We'll probably want more logic involved later. For now, it's okay hide all "respond" UI items when not logged in. The only time they should show up for users not logged in is when the system is in peer-to-peer mode
<!--
A summary of what problem this pull request is trying to solve. Include a #reference to an existing issue, which should provide a more detailed explanation of the problem, as well as any discussion about the nature of the problem.

If appropriate, use github's [issue linking keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to automatically close any issues that this pull request resolves.
-->

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [x] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation
- [x] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [x] New features have been documented, and the code is understandable and well commented
- [x] Entry added to CHANGELOG.md if appropriate

## What


Also, I added some tests, pulling some test data from my dev environment
<!--
A list of the changes included in this pull request. A checkbox list is probably a good choice here, and the boxes should be checked off as tasks are completed. This section may be omitted if the Why section provides enough information and only a few changes were made (eg, for simple bug reports).

Always highlight breaking changes or any changes that effect the behaviour of user facing components of the application

- [ ] Put your changes in a list like this
- [x] Then you can check them off like this!


Also, include screenshots if you can!
-->
When not logged in, viewing tiles:
![Screen Shot 2021-01-18 at 2 01 46 PM](https://user-images.githubusercontent.com/3620291/104954922-422b4d80-5997-11eb-9b19-b1b3006da10c.png)

When not logged in, viewing the list:

![Screen Shot 2021-01-18 at 2 01 40 PM](https://user-images.githubusercontent.com/3620291/104954929-46576b00-5997-11eb-9658-13665c7c2989.png)

When logged in viewing tiles:
![Screen Shot 2021-01-18 at 2 02 04 PM](https://user-images.githubusercontent.com/3620291/104954858-1e680780-5997-11eb-90cb-52691a5bda0f.png)

When logged in viewing the list:
![Screen Shot 2021-01-18 at 2 01 16 PM](https://user-images.githubusercontent.com/3620291/104954880-2c1d8d00-5997-11eb-9f28-a6d8c1c13284.png)


## How
The two key changes are 

- a line in the controller that makes the respond link conditional
- a line in the list view that hides the "Respond" header of no controllers have data for it

### Testing
<!--
If possible you should add tests to ensure that any changes you make work as expected! Describe the tests you added, or make note of anything you couldn't figure out how to test. You don't need to go into a whole lot of detail (good tests should be pretty self explanatory) but at a minimum make note of where you put any new tests in the code base.

IF YOU CHANGED THE BEHAVIOR OF ANY TESTS THAT WERE PREVIOUSLY IMPLEMENTED ALWAYS MAKE A NOTE OF IT AND DESCRIBE WHAT YOU CHANGED AND WHY!
-->


## Next Steps
<!--
This section is to highlight any ideas you have for how this feature could be extended in the future.

You should also consider adding issues for these next steps
-->

## Outstanding Questions, Concerns and Other Notes
<!--
Any questions or concerns you were unable to address while implementing this solution. For example, "I've implemented heat vision resistance, but do we expect to be attacked by superman?"

If you find that this section is getting long, or the questions and concerns have a significant impact on the quality of this solution, consider making this a ["draft"](https://github.blog/2019-02-14-introducing-draft-pull-requests/) pull request to ensure that it is not merged until it is ready.

This may be another place where a checklist is a good choice, so people can see which questions have been resolved.
-->

### Accessibility
<!--
If this change will make any significant changes to either physical accessibility (eg, making the website work better with screenreaders) or technical accessibility (eg, making the website load faster for people with marginal internet), you should explain what they are, and highlight any issues or concerns you might have that haven't been resolved.
-->

This should not change accessibility as it makes an existing UI element entirely hidden conditionally

### Security
<!--
Address how this change will improve/lessen the security of the application - for example, it improves HTML sanitization or opens a new attack surface. Always explain so that developers without a security background can understand. Similarly, address how this change will impact the accessibility of the application. Be sure to address both physical accessibility (eg, making the website work better with screenreaders) and technical accessibility (eg, making the website load faster for people with marginal internet). If you're not sure what to put here, don't worry! Just explain what you can, and make sure to note that you think this issue needs to be reviewed with security & accessibility in mind
-->
This is pretty reasonable, security-wise. The decision to expose the information is being made server-side, so there's no way a user could spy on the info only from the client. That, and the URLs that are being exposed have authorization controls around them, so there's not much risk if they were exposed.

### Meta
<!--
Any additional notes you have regarding your experience working on this pull request as a contributor. If this is very detailed, it could be a good idea to create an issue to address it.
-->
