### PR TITLE
Rename acting_user accessor in policies

### DIFF
--- a/app/policies/announcement_policy.rb
+++ b/app/policies/announcement_policy.rb
@@ -12,7 +12,7 @@ class AnnouncementPolicy < ApplicationPolicy
 
   class Scope < ApplicationPolicy::Scope
     def resolve
-      can_admin? ? original_scope : original_scope.published
+      can_admin? ? scope : scope.published
     end
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,13 +1,13 @@
 class ApplicationPolicy
   module Utils
-    attr_reader :acting_user, :admin_param, :system_settings
+    attr_reader :user, :admin_param, :system_settings
 
     def sys_admin?
-      acting_user && acting_user.sys_admin_role? && admin_param != 'false'
+      user && user.sys_admin_role? && admin_param != 'false'
     end
 
     def admin?
-      acting_user && acting_user.admin_role? && admin_param != 'false'
+      user && user.admin_role? && admin_param != 'false'
     end
 
     def can_admin?
@@ -33,7 +33,7 @@ class ApplicationPolicy
     attr_reader :original_scope
 
     def initialize(context, original_scope)
-      @acting_user, @system_settings, @admin_param = extract context
+      @user, @system_settings, @admin_param = extract context
       @original_scope = original_scope
     end
 
@@ -47,7 +47,7 @@ class ApplicationPolicy
 
   # We've configured pundit to provide a user context (See https://github.com/varvet/pundit/#additional-context).
   def initialize(context, record)
-    @acting_user, @system_settings, @admin_param = extract context
+    @user, @system_settings, @admin_param = extract context
     @record = record
   end
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -30,16 +30,16 @@ class ApplicationPolicy
   class Scope
     include Utils
 
-    attr_reader :original_scope
+    attr_reader :scope
 
-    def initialize(context, original_scope)
+    def initialize(context, scope)
       @user, @system_settings, @admin_param = extract context
-      @original_scope = original_scope
+      @scope = scope
     end
 
     # We default all permissions to false, and expect you to override as needed.
     def resolve
-      original_scope.none
+      scope.none
     end
   end
 

--- a/app/policies/claim_policy.rb
+++ b/app/policies/claim_policy.rb
@@ -1,5 +1,5 @@
 class ClaimPolicy < ApplicationPolicy
   def add?
-    acting_user.present? && system_settings.peer_to_peer?
+    user.present? && system_settings.peer_to_peer?
   end
 end

--- a/app/policies/community_resource_policy.rb
+++ b/app/policies/community_resource_policy.rb
@@ -25,7 +25,7 @@ class CommunityResourcePolicy < ApplicationPolicy
 
   class Scope < ApplicationPolicy::Scope
     def resolve
-      can_admin? ? original_scope : original_scope.published
+      can_admin? ? scope : scope.published
     end
   end
 end

--- a/app/policies/glossary_policy.rb
+++ b/app/policies/glossary_policy.rb
@@ -1,9 +1,4 @@
 class GlossaryPolicy < ApplicationPolicy
-  def read?
-    true
-  end 
-
-  def change?
-    acting_user && (acting_user.admin_role? || acting_user.sys_admin_role? )
-  end
+  def read?;   true        end
+  def change?; can_admin?  end
 end

--- a/app/policies/nav_bar_policy.rb
+++ b/app/policies/nav_bar_policy.rb
@@ -1,8 +1,8 @@
 class NavBarPolicy < ApplicationPolicy
   def visible_buttons
     visible = Set.new
-    visible << (acting_user ? 'Logout' : 'Login')
-    visible << 'Feedback' if acting_user
+    visible << (user ? 'Logout' : 'Login')
+    visible << 'Feedback' if user
     visible << 'Contributions' if system_settings.peer_to_peer?
     visible.merge %w[Contributions Matches Admin] if can_admin?
     visible.to_a

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -4,8 +4,8 @@ class PersonPolicy < ApplicationPolicy
       case
       when can_admin?
         original_scope.all
-      when acting_user.present?
-        original_scope.where(user_id: acting_user.id)
+      when user.present?
+        original_scope.where(user_id: user.id)
       else
         original_scope.none
       end
@@ -13,15 +13,15 @@ class PersonPolicy < ApplicationPolicy
   end
 
   def read?
-    person_attached_to_acting_user? || can_admin?
+    own_person? || can_admin?
   end
 
   def change?
-    person_attached_to_acting_user? || can_admin?
+    own_person? || can_admin?
   end
 
   def add?
-    person_attached_to_acting_user? || sys_admin?
+    own_person? || sys_admin?
   end
 
   def delete?
@@ -29,11 +29,12 @@ class PersonPolicy < ApplicationPolicy
   end
 
   private
+
   def person
     record
   end
 
-  def person_attached_to_acting_user?
-    person.user_id == acting_user&.id
+  def own_person?
+    person.user_id == user&.id
   end
 end

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -3,11 +3,11 @@ class PersonPolicy < ApplicationPolicy
     def resolve
       case
       when can_admin?
-        original_scope.all
+        scope.all
       when user.present?
-        original_scope.where(user_id: user.id)
+        scope.where(user_id: user.id)
       else
-        original_scope.none
+        scope.none
       end
     end
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -4,8 +4,8 @@ class UserPolicy < ApplicationPolicy
       case
       when can_admin?
         original_scope.all
-      when acting_user.present?
-        original_scope.where(id: acting_user.id)
+      when user.present?
+        original_scope.where(id: user.id)
       else
         original_scope.none
       end
@@ -13,11 +13,11 @@ class UserPolicy < ApplicationPolicy
   end
 
   def read?
-    target_user_is_acting_user? || can_admin?
+    own_user? || can_admin?
   end
 
   def change?
-    target_user_is_acting_user? || can_admin?
+    own_user? || can_admin?
   end
 
   def add?
@@ -33,7 +33,7 @@ class UserPolicy < ApplicationPolicy
     record
   end
 
-  def target_user_is_acting_user?
-    acting_user.present? && target_user == acting_user
+  def own_user?
+    user.present? && target_user == user
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -3,11 +3,11 @@ class UserPolicy < ApplicationPolicy
     def resolve
       case
       when can_admin?
-        original_scope.all
+        scope.all
       when user.present?
-        original_scope.where(id: user.id)
+        scope.where(id: user.id)
       else
-        original_scope.none
+        scope.none
       end
     end
   end

--- a/spec/policies/announcement_policy_spec.rb
+++ b/spec/policies/announcement_policy_spec.rb
@@ -1,12 +1,5 @@
 require 'rails_helper'
 
-# FIXME: remove or consolidate this block once #834 is resolved
-RSpec.configure do
-  Pundit::Matchers.configure do |config|
-    config.user_alias = :acting_user
-  end
-end
-
 RSpec.describe AnnouncementPolicy do
   let(:context) { Context.new user: user }
   let(:announcement) { double :announcement }

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe ApplicationPolicy do
 
   describe 'initialization' do
     it 'accepts Context and extracts its contents' do
-      expect(policy.acting_user).to be user
+      expect(policy.user).to be user
       expect(policy.system_settings).to be system_settings
     end
 
     it 'also supports User instead of context' do
       policy = ApplicationPolicy.new user, record
-      expect(policy.acting_user).to be user
+      expect(policy.user).to be user
       expect(policy.system_settings).to be nil
     end
   end

--- a/spec/policies/claim_policy_spec.rb
+++ b/spec/policies/claim_policy_spec.rb
@@ -1,12 +1,5 @@
 require 'spec_helper'
 
-# FIXME: remove or consolidate this block once #834 is resolved
-RSpec.configure do
-  Pundit::Matchers.configure do |config|
-    config.user_alias = :acting_user
-  end
-end
-
 RSpec.describe ClaimPolicy do
   let(:system_settings) { double :system_setting }
   let(:context) { Context.new user: user, system_settings: system_settings }

--- a/spec/policies/community_resource_policy_spec.rb
+++ b/spec/policies/community_resource_policy_spec.rb
@@ -1,12 +1,5 @@
 require 'rails_helper'
 
-# FIXME: remove or consolidate this block once #834 is resolved
-RSpec.configure do
-  Pundit::Matchers.configure do |config|
-    config.user_alias = :acting_user
-  end
-end
-
 RSpec.describe CommunityResourcePolicy do
   let(:context) { Context.new user: user }
   let(:community_resource) { double :community_resource }

--- a/spec/policies/contribution_policy_spec.rb
+++ b/spec/policies/contribution_policy_spec.rb
@@ -1,12 +1,5 @@
 require 'spec_helper'
 
-# FIXME: remove or consolidate this block once #834 is resolved
-RSpec.configure do
-  Pundit::Matchers.configure do |config|
-    config.user_alias = :acting_user
-  end
-end
-
 RSpec.describe ContributionPolicy do
   let(:context) { Context.new user: user }
   let(:contribution) { double :contribution }


### PR DESCRIPTION
### Why
Definite tradeoffs in both directions but after a group discussion, felt that new engineers having to investigate/learn another term wasn't worth the benefits of the explicit qualification.

### Pre-Merge Checklist
- [ ] Talk to @bhaibel 
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation

### What
1. Dropping back to `user` -- the term used in pundit docs/examples with the understanding that any _other_ users in play can be qualified as needed.
1. Rename a couple of related private methodes in `UserPolicy` and `PersonPolicy`
1. Also renames `original_scope` to `scope`. Doesn't feel like the qualification is necessary so falling back to the
term used in pundit docs/examples.

Note: this changeset builds on #833 which first drops some spec code that uses the same term.

### Outstanding Questions, Concerns and Other Notes
We discussed that we'd love @bhaibel  to weigh in on this since she likely considered these tradeoffs. We'd ideally not merge these suggested changes until we have a chance to talk to her.
