### PR TITLE
Solution to secure admin-only resources

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class AdminController < ApplicationController
-  include NotUsingPunditYet
-
-  before_action :authenticate_user!, except: %i[new create]
+  before_action :authenticate_user!
+  before_action :ensure_authorized_as_admin
   before_action :set_system_settings, only: [:glossary_edit, :glossary_index, :glossary_update]
 
   def landing_page
@@ -38,7 +37,7 @@ class AdminController < ApplicationController
     @system_settings.update(glossary_content: glossary_params[:glossary_content])
     redirect_to glossary_admin_path
   end
-  
+
   def yearbook
     @positions = Position.all
   end
@@ -51,5 +50,14 @@ class AdminController < ApplicationController
 
   def set_system_settings
     @system_settings = SystemSetting.current_settings
+  end
+
+  def ensure_authorized_as_admin
+    unless current_user.admin_role? || current_user.sys_admin_role?
+      fail Pundit::NotAuthorizedError, "Sorry, only admins are authorized to do that."
+    end
+
+    skip_authorization
+    skip_policy_scope
   end
 end

--- a/app/controllers/contact_methods_controller.rb
+++ b/app/controllers/contact_methods_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class ContactMethodsController < ApplicationController
-  include NotUsingPunditYet
-
+class ContactMethodsController < AdminController
   before_action :set_contact_method, only: %i[show edit update destroy]
 
   def index

--- a/spec/requests/admin_authorization_spec.rb
+++ b/spec/requests/admin_authorization_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'authorization of admin-only controllers', type: :request do
+  let(:sample_controller_path) { contact_methods_path }
+
+  before { login_as user }
+
+  describe 'as a guest' do
+    let(:user) { nil }
+
+    it 'requires login' do
+      get sample_controller_path
+      expect(response).to redirect_to new_user_session_path
+    end
+  end
+
+  describe 'as a dispatcher' do
+    let(:user) { create :user, :dispatcher }
+
+    it 'denies access' do
+      get sample_controller_path
+      expect(response).to have_http_status :forbidden
+    end
+  end
+
+  describe 'as an admin' do
+    let(:user) { create :user, :admin }
+
+    it 'allows access' do
+      get sample_controller_path
+      expect(response).to be_successful
+    end
+  end
+end


### PR DESCRIPTION
### Why
Before we open up user registration, we have to secure any pages that should only be accessible to admins (sysadmins). This actually turns out to be the vast majority of our controllers, so ideally we can solve this w/o a lot of drudge work.

### Pre-Merge Checklist
- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [x] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [x] New features have been documented, and the code is understandable and well commented
- [ ] All outstanding questions and concerns have been resolved
- [x] Any next steps that seem like good ideas have been created as issues for future discussion & implementation

### What
- [x] Add code to `AdminController` that ensures current_user is an admin || sysadmin
- [x] Show sample implementation with one admin-only controller (`ContactMethodsController`)

### How
* With `pundit`, we would usually `authorize` each action independently and create policy classes for each resource.
* For admin-only resources, this seems like overkill: these controllers and actions all require exactly the same check.
* Inheriting this logic from a base controller in the form of a `before_action` seems like a simpler solution.
* Currently, `AdminController` contains a bunch of non-restful actions. I recommend we extract them out into their own controllers so `AdminController` can become an abstract base class.

### Testing
Added a spec specifically around the simple auth introduced in `AdminController`. It uses `ContactMethodsController` as a sample admin-only resource.

### Next Steps
- [ ] Extract restful controllers out of the existing actions in `AdminController` since we don't want all subclasses to inherit this extraneous logic (#836).
- [ ] Make other admin-only controllers subclasses of `AdminController` (#837).

### Outstanding Questions, Concerns and Other Notes
?
