### PR TITLE
Add simple auth to all admin-only controllers

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class CategoriesController < ApplicationController
-  include NotUsingPunditYet
-
+class CategoriesController < AdminController
   before_action :set_category, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/communication_logs_controller.rb
+++ b/app/controllers/communication_logs_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class CommunicationLogsController < ApplicationController
-  include NotUsingPunditYet
-
+class CommunicationLogsController < AdminController
   before_action :set_communication_log, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/custom_form_questions_controller.rb
+++ b/app/controllers/custom_form_questions_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class CustomFormQuestionsController < ApplicationController
-  include NotUsingPunditYet
-
+class CustomFormQuestionsController < AdminController
   before_action :set_custom_form_question, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class DonationsController < ApplicationController
-  include NotUsingPunditYet
-
+class DonationsController < AdminController
   before_action :authenticate_user!, except: %i[new create]
   before_action :set_donation, only: %i[show edit update destroy]
 

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-class FeedbacksController < ApplicationController
-  include NotUsingPunditYet
-
+# FIXME: Will need to become a mixed-access controller when we add functionality for
+# neigbhors to create feedback. Maybe also consider renaming (MatchFeedback)?
+class FeedbacksController < AdminController
   before_action :set_feedback, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/form_questions_controller.rb
+++ b/app/controllers/form_questions_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class FormQuestionsController < ApplicationController
-  include NotUsingPunditYet
-
+class FormQuestionsController < AdminController
   before_action :set_form_question, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class FormsController < ApplicationController
-  include NotUsingPunditYet
-
+class FormsController < AdminController
   before_action :set_form, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/history_logs_controller.rb
+++ b/app/controllers/history_logs_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class HistoryLogsController < ApplicationController
-  include NotUsingPunditYet
-
+class HistoryLogsController < AdminController
   def index
     @history_logs = HistoryLog.all
   end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class ListingsController < ApplicationController
-  include NotUsingPunditYet
-
+class ListingsController < AdminController
   before_action :set_listing, only: %i[show edit update destroy match match_confirm]
 
   def index

--- a/app/controllers/location_types_controller.rb
+++ b/app/controllers/location_types_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class LocationTypesController < ApplicationController
-  include NotUsingPunditYet
-
+class LocationTypesController < AdminController
   before_action :set_location_type, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class LocationsController < ApplicationController
-  include NotUsingPunditYet
-
+class LocationsController < AdminController
   before_action :set_location, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class MatchesController < ApplicationController
-  include NotUsingPunditYet
-
+class MatchesController < AdminController
   before_action :set_match, only: %i[edit update destroy]
 
   def index

--- a/app/controllers/mobility_string_translations_controller.rb
+++ b/app/controllers/mobility_string_translations_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class MobilityStringTranslationsController < ApplicationController
-  include NotUsingPunditYet
-
+class MobilityStringTranslationsController < AdminController
   before_action :set_mobility_string_translation, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class OrganizationsController < ApplicationController
-  include NotUsingPunditYet
-
+class OrganizationsController < AdminController
   before_action :set_organization, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/positions_controller.rb
+++ b/app/controllers/positions_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class PositionsController < ApplicationController
-  include NotUsingPunditYet
-
+class PositionsController < AdminController
   before_action :set_position, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/service_areas_controller.rb
+++ b/app/controllers/service_areas_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class ServiceAreasController < ApplicationController
-  include NotUsingPunditYet
-
+class ServiceAreasController < AdminController
   before_action :set_service_area, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/shared_accounts_controller.rb
+++ b/app/controllers/shared_accounts_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class SharedAccountsController < ApplicationController
-  include NotUsingPunditYet
-
+class SharedAccountsController < AdminController
   before_action :set_shared_account, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/shift_matches_controller.rb
+++ b/app/controllers/shift_matches_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class ShiftMatchesController < ApplicationController
-  include NotUsingPunditYet
-
+class ShiftMatchesController < AdminController
   before_action :set_shift_match, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class ShiftsController < ApplicationController
-  include NotUsingPunditYet
-
+class ShiftsController < AdminController
   before_action :set_shift, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/software_feedbacks_controller.rb
+++ b/app/controllers/software_feedbacks_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class SoftwareFeedbacksController < ApplicationController
-  include NotUsingPunditYet
-
+class SoftwareFeedbacksController < AdminController
   before_action :set_software_feedback, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/submission_response_imports_controller.rb
+++ b/app/controllers/submission_response_imports_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class SubmissionResponseImportsController < ApplicationController
-  include NotUsingPunditYet
-
+class SubmissionResponseImportsController < AdminController
   def new; end
 
   def create

--- a/app/controllers/submission_responses_controller.rb
+++ b/app/controllers/submission_responses_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class SubmissionResponsesController < ApplicationController
-  include NotUsingPunditYet
-
+class SubmissionResponsesController < AdminController
   before_action :set_submission_response, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class SubmissionsController < ApplicationController
-  include NotUsingPunditYet
-
+class SubmissionsController < AdminController
   before_action :set_submission, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/system_locales_controller.rb
+++ b/app/controllers/system_locales_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class SystemLocalesController < ApplicationController
-  include NotUsingPunditYet
-
+class SystemLocalesController < AdminController
   before_action :set_system_locale, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/system_settings_controller.rb
+++ b/app/controllers/system_settings_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class SystemSettingsController < ApplicationController
-  include NotUsingPunditYet
-
+class SystemSettingsController < AdminController
   before_action :set_system_setting, only: %i[show edit update destroy]
   before_action :set_primary_organization, only: %i[show edit update destroy]
 

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class TeamsController < ApplicationController
-  include NotUsingPunditYet
-
+class TeamsController < AdminController
   before_action :set_team, only: %i[show edit update destroy]
 
   def index

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -67,7 +67,7 @@ class Listing < ApplicationRecord
     elsif matches_as_provider.any?
       status = matches_as_provider.map{|m| m.completed?}.any? ? 'completed' : 'matched'
     end
-    update_attributes(state: status)
+    update(state: status)
     status
   end
 

--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe '/listings', type: :request do
     location_attributes: { zip: '12e45' },
   }}
 
-  before { sign_in create(:user) }
+  before { sign_in create(:user, :admin) }
 
   describe 'GET /index' do
     it 'renders a successful response' do


### PR DESCRIPTION
### Why
Gives all admin-only controllers rudimentary authorization by inheriting from `AdminController`.

See #835 for background.

### Pre-Merge Checklist
- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [ ] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation

### Testing
This is part of the work to re-open user registration.
Once all that work is ready, we'll need to do some extensive manual regression testing.

### Specific review requests
Most importantly, please check whether all these controllers are actually only for admin use.

### Next Steps
?

### Outstanding Questions, Concerns and Other Notes
?
