### PR TITLE
Introduce pundit user context

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ClaimsController < ApplicationController
-  include NotUsingPunditYet
+  before_action { authorize :claim }
 
   def new
     contribution = Listing.find(params[:contribution_id])
@@ -11,7 +11,7 @@ class ClaimsController < ApplicationController
     end
     render locals: {
       contribution: contribution,
-      email: current_person&.email
+      email: current_user.person&.email
     }
   end
 
@@ -21,11 +21,5 @@ class ClaimsController < ApplicationController
       current_user: current_user
     ))
     redirect_to contribution_path(params[:contribution_id]), notice: 'Claim was successful!'
-  end
-
-  private
-
-  def current_person
-    current_user.person
   end
 end

--- a/app/controllers/concerns/authorization.rb
+++ b/app/controllers/concerns/authorization.rb
@@ -8,6 +8,11 @@ module Authorization
     after_action :verify_policy_scoped, only: :index, unless: :devise_controller?
 
     rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+    # define this late so it will override the one in the Pundit module
+    define_method(:pundit_user) do
+      UserContext.new(current_user, SystemSetting.current_settings)
+    end
   end
 
   module ClassMethods

--- a/app/models/user_context.rb
+++ b/app/models/user_context.rb
@@ -1,0 +1,1 @@
+UserContext = Struct.new(:user, :system_settings)

--- a/app/policies/claim_policy.rb
+++ b/app/policies/claim_policy.rb
@@ -1,0 +1,5 @@
+class ClaimPolicy < ApplicationPolicy
+  def add?
+    acting_user.present? && system_settings.peer_to_peer?
+  end
+end

--- a/spec/policies/claim_policy_spec.rb
+++ b/spec/policies/claim_policy_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+# FIXME: remove or consolidate this block once #834 is resolved
+RSpec.configure do
+  Pundit::Matchers.configure do |config|
+    config.user_alias = :acting_user
+  end
+end
+
+RSpec.describe ClaimPolicy do
+  let(:system_settings) { double :system_setting }
+  let(:user_context)    { UserContext.new user, system_settings }
+
+  subject { ClaimPolicy.new(user_context, :claim) }
+
+  context 'with a guest user' do
+    let(:user) { nil }
+
+    it { is_expected.to forbid_new_and_create_actions }
+  end
+
+  context 'with an authenticated user' do
+    let(:user) { double :user }
+
+    context 'in dispatch mode' do
+      before { allow(system_settings).to receive(:peer_to_peer?).and_return(false) }
+
+      it { is_expected.to forbid_new_and_create_actions }
+    end
+
+    context 'in peer to peer mode' do
+      before { allow(system_settings).to receive(:peer_to_peer?).and_return(true) }
+
+      it { is_expected.to permit_new_and_create_actions }
+    end
+  end
+end


### PR DESCRIPTION
### Why
A lot of our policies will rely on `SystemSettings`. The [recommended way](https://github.com/varvet/pundit/#additional-context) to provide such additional context is to wrap a custom object around the `user` injected into policy initializers.

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [x] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [x] New features have been documented, and the code is understandable and well commented
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation

### What
* Override `pundit_user` to provide a custom `UserContext` instead of a plain `User`.
* The `UserContext` is then decomposed in `ApplicationPolicy` so that the change is tranparent to sub classes.
* Add `ClaimPolicy` and `...Spec` as examples of accessing `SystemSettings` in policies.

### How
We could instead have accessed `SystemSettings.current_settings` directly from any policies that need it. While that would certainly have been more straightforward, i preferred this solution for two reasons:
1. The solution here adheres to the Dependency Inversion principle.
2. Consequently, it makes testing much simpler; we don't have to instrument `SystemSetting` class methods and in fact don't have to refer to the real `SystemSetting` class at all. Note how `claim_policy_spec` doesn't even `require 'rails_helper`; it's a plain ruby spec making use of very simple test doubles.

The implementation also allows `ApplicationPolicy` to work if a `User` is passed in instead of the expected `UserContext`. This allows most policy specs to not worry about `UserContext` and will also catch us if we have to explicitly create policies in prod code (instead of relying on `authorize` to create them).

One last implementation detail: note the placement of our `pundit_user` method definition. The `included` block in the concern is run _after_ any instance methods are mixed in; defining it before then won't work.

### Testing
Our existing request specs were able to cover this change.

### Next Steps
?

### Outstanding Questions, Concerns and Other Notes
?

### Meta
I initially defined `pundit_user` in the main body of `concerns/authorization.rb`, expecting it to overide pundit's default implementation. It took a long while to track down the inclusion order issue mentioned above. One more reason to stay away from `ActiveSupport::Concern`s 🤯
