### PR TITLE
Open fully public controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include Authorization
 
   protect_from_forgery with: :exception
+
   before_action :authenticate_user!
   before_action :set_admin_status
   before_action :set_system_setting

--- a/app/controllers/asks_controller.rb
+++ b/app/controllers/asks_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class AsksController < PublicController
-  include NotUsingPunditYet
-
   layout 'without_navbar', only: %i[new create]
 
   def index

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class OffersController < PublicController
-  include NotUsingPunditYet
-
   layout 'without_navbar', only: %i[new create]
 
   def index

--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PublicController < ApplicationController
-  include NotUsingPunditYet
-
   skip_before_action :authenticate_user!
+  skip_after_action  :verify_authorized
+  skip_after_action  :verify_policy_scoped
 end

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -1,16 +1,11 @@
 # frozen_string_literal: true
 
+# FIXME: Extract actions into separate controllers or consolidate with existing ones
 class PublicPagesController < PublicController
-  include NotUsingPunditYet
-
   layout :determine_layout
 
   def about
     @about_us_text = HtmlSanitizer.new(@system_setting.about_us_text).sanitize
-  end
-
-  def determine_layout
-    'without_navbar' unless @system_setting.display_navbar?
   end
 
   def announcements
@@ -46,5 +41,11 @@ class PublicPagesController < PublicController
       status: version,
       color: 'blue'
     }
+  end
+
+  private
+
+  def determine_layout
+    'without_navbar' unless @system_setting.display_navbar?
   end
 end


### PR DESCRIPTION
### Why
As we consolidate our authorization solution, there are a handful of controllers that are fully public and don't need authentication or authorization. This is codified in `PublicController`

### Pre-Merge Checklist
- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [ ] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [x] New features have been documented, and the code is understandable and well commented
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation


### Next Steps
See #840.

And once we're done with this push, it could be useful to review where we've landed with:
* `Authorization` concern
* `ApplicationController`
* `AdminController`
* `PublicController`

### Outstanding Questions, Concerns and Other Notes
?
