### PR TITLE
Introduce context

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -52,7 +52,7 @@ class AnnouncementsController < ApplicationController
     end
 
     def determine_layout
-      'without_navbar' unless @system_setting.display_navbar?
+      'without_navbar' unless context.system_settings.display_navbar?
     end
 
     def announcement_params

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,11 @@ class ApplicationController < ActionController::Base
     { locale: I18n.locale }
   end
 
+  def context
+    @context ||= Context.new(user: current_user)
+  end
+  helper_method :context
+
   private
 
   # TODO: this appears to be unused?

--- a/app/controllers/concerns/authorization.rb
+++ b/app/controllers/concerns/authorization.rb
@@ -10,9 +10,7 @@ module Authorization
     rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
     # define this late so it will override the one in the Pundit module
-    define_method(:pundit_user) do
-      UserContext.new(current_user, SystemSetting.current_settings)
-    end
+    define_method(:pundit_user) { context } # see ApplicationController#context
   end
 
   module ClassMethods

--- a/app/lib/user_role.rb
+++ b/app/lib/user_role.rb
@@ -4,7 +4,7 @@ class UserRole
   ROLES = %w(unset neighbor volunteer dispatcher admin sys_admin).freeze
 
   def self.roles_as_hash
-  	ROLES.map { |r| [r.to_sym, r] }.to_h
+    ROLES.map { |r| [r.to_sym, r] }.to_h
   end
 
   def initialize(role)

--- a/app/models/context.rb
+++ b/app/models/context.rb
@@ -1,0 +1,10 @@
+Context = Struct.new(
+  :system_settings,
+  :user,
+  keyword_init: true
+) do
+
+  def system_settings
+    self[:system_settings] ||= SystemSetting.current_settings
+  end
+end

--- a/app/models/context.rb
+++ b/app/models/context.rb
@@ -7,4 +7,11 @@ Context = Struct.new(
   def system_settings
     self[:system_settings] ||= SystemSetting.current_settings
   end
+
+  def to_h
+    {
+      system_settings: system_settings,
+      user: user,
+    }
+  end
 end

--- a/app/models/user_context.rb
+++ b/app/models/user_context.rb
@@ -1,1 +1,0 @@
-UserContext = Struct.new(:user, :system_settings)

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -10,11 +10,11 @@ class ApplicationPolicy
 
     private
 
-    # Allowing for user_context || user simplifies policy specs that don't use additional context.
-    def extract(user_context)
+    # Allowing for context || user simplifies policy specs that don't use additional context.
+    def extract(context)
       [
-        user_context.respond_to?(:user) ? user_context.user : user_context,
-        user_context.respond_to?(:system_settings) ? user_context.system_settings : nil,
+        context.respond_to?(:user) ? context.user : context,
+        context.respond_to?(:system_settings) ? context.system_settings : nil,
       ]
     end
   end
@@ -24,8 +24,8 @@ class ApplicationPolicy
     include Utils
     attr_reader :acting_user, :original_scope
 
-    def initialize(user_context, original_scope)
-      @acting_user, @system_settings = extract user_context
+    def initialize(context, original_scope)
+      @acting_user, @system_settings = extract context
       @original_scope = original_scope
     end
 
@@ -37,9 +37,9 @@ class ApplicationPolicy
 
   attr_reader :acting_user, :record, :system_settings
 
-  # We've configured pundit to provide a UserContext (See https://github.com/varvet/pundit/#additional-context).
-  def initialize(user_context, record)
-    @acting_user, @system_settings = extract user_context
+  # We've configured pundit to provide a user context (See https://github.com/varvet/pundit/#additional-context).
+  def initialize(context, record)
+    @acting_user, @system_settings = extract context
     @record = record
   end
 

--- a/spec/models/context_spec.rb
+++ b/spec/models/context_spec.rb
@@ -36,4 +36,19 @@ RSpec.describe Context do
       context.system_settings
     end
   end
+
+  describe 'to_h' do
+    let(:user) { double 'User' }
+    let(:system_settings) { double 'SystemSettings' }
+    let(:context) { Context.new user: user, system_settings: system_settings }
+
+    def method_with_keyword_args positional_arg, non_context_keyword_arg:, user:, system_settings:
+      [positional_arg, non_context_keyword_arg, user, system_settings]
+    end
+
+    it 'can be converted to a hash and passed as keyword args' do
+      expect(method_with_keyword_args 'positional', non_context_keyword_arg: 'non_context', **context.to_h).
+        to eq ['positional', 'non_context', user, system_settings]
+    end
+  end
 end

--- a/spec/models/context_spec.rb
+++ b/spec/models/context_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe Context do
+  describe 'initialization' do
+    it 'allows keyword init' do
+      context = Context.new user: double(:user)
+      expect(context.user).to be_present
+    end
+
+    it 'allows args to be omitted' do
+      context = Context.new
+      expect(context.user).to be_nil
+    end
+  end
+
+  describe 'lazy, memoized, overridable readers' do
+    let(:current_settings) { double :current_settings }
+    let(:system_setting) { class_double('SystemSetting').as_stubbed_const }
+    let(:context) { Context.new }
+
+    it 'is lazy' do
+      expect(system_setting).to receive(:current_settings) { current_settings }
+      expect(context.system_settings).to be current_settings
+    end
+
+    it 'is memoized' do
+      expect(system_setting).to receive(:current_settings).once { current_settings }
+      context.system_settings
+      context.system_settings
+    end
+
+    it 'can be overriden' do
+      expect(system_setting).to receive(:current_settings).never
+      context.system_settings = double(:override)
+      context.system_settings
+    end
+  end
+end

--- a/spec/models/context_spec.rb
+++ b/spec/models/context_spec.rb
@@ -13,23 +13,24 @@ RSpec.describe Context do
     end
   end
 
-  describe 'lazy, memoized, overridable readers' do
+  describe 'custom reader methods' do
     let(:current_settings) { double :current_settings }
     let(:system_setting) { class_double('SystemSetting').as_stubbed_const }
     let(:context) { Context.new }
 
-    it 'is lazy' do
-      expect(system_setting).to receive(:current_settings) { current_settings }
+    example 'can be lazy' do
+      expect(context[:system_settings]).to be_nil # not provided during initialization
+      expect(system_setting).to receive(:current_settings).and_return current_settings
       expect(context.system_settings).to be current_settings
     end
 
-    it 'is memoized' do
-      expect(system_setting).to receive(:current_settings).once { current_settings }
+    example 'can be memoized' do
+      expect(system_setting).to receive(:current_settings).once.and_return current_settings
       context.system_settings
       context.system_settings
     end
 
-    it 'can be overriden' do
+    example 'can be overriden' do
       expect(system_setting).to receive(:current_settings).never
       context.system_settings = double(:override)
       context.system_settings

--- a/spec/policies/claim_policy_spec.rb
+++ b/spec/policies/claim_policy_spec.rb
@@ -9,9 +9,9 @@ end
 
 RSpec.describe ClaimPolicy do
   let(:system_settings) { double :system_setting }
-  let(:user_context)    { UserContext.new user, system_settings }
+  let(:context) { Context.new user: user, system_settings: system_settings }
 
-  subject { ClaimPolicy.new(user_context, :claim) }
+  subject { ClaimPolicy.new(context, :claim) }
 
   context 'with a guest user' do
     let(:user) { nil }


### PR DESCRIPTION
### Why
This changeset was motivated by the proliferation of inherited @variables in many of our controllers, eg `@system_setting`.

It's bad practice to reference superclass instance variables because it creates very tight coupling up and down the inheritance chain. These variables essentially become globals.

In rails, this problem is usually solved in one of several ways. Taking `@system_setting` as an example:
* Wrap variables in attr_readers, eg `attr_reader :system_setting`. This is an improvement but still maintains coupling between super and sup classes.
* Mix in a module containing an accessor. This is an improvement because it doesn't force accessors onto other classes in the inheritance chain that don't need it. There are still a couple of downsides:
  * There are usually a number of accessors in play; authors have to discover and bring in multiple modules.
  * Because accessors are mixed directly into the controller, the coupling is still tight; there isn't a distinct 'seam' between the controller and the dependency, so we have to mock/override accessors. Again, if there are several accessors in play, this can get cumbersome.
* Dropping the accessor and getting the underlying data directly, usually via a class method, eg `SystemSetting.current_settings`. Eliminates the sub/super coupling, replacing it with direct coupling; the coupling shifts from 'vertical' to 'horizontal'. This makes the seam much clearer but still suffers violates the Dependency Inversion principle and can also lead to duplication.

Further, all the solutions above only help at the controller layer. We often need to access some of these variables in other layers such as Interactors or Serializers. A good example of this is needing access to `current_user` outside of controllers.

This changeset outlines an alternative that i believe minimizes all these concerns.

### What and How
  1. Introduces `Context`, a thin wrapper providing access to 'globals' such as `system_settings` and `current_user`. This serves as a single point of access to any 'context' we might need.
  1. `Context` can be initialized with data or filled out later via attr_writers.
  1. It can also lazily retrieve and memoize data (see Context#system_settings).
  1. This new class turns out to be a practical and semantic superset of `UserContext`, so they've been consolidated.
  1. Shows a simple example of usage in `AnnouncementsController`

### Testing
- [x] `app/models/context_spec.rb`

### Next Steps
- [x] Refactor `AnnouncementsController` to drop `@admin_status` in favor of `context.can_admin?` #845 
- [ ] ?

### Outstanding Questions, Concerns and Other Notes
?

### Meta
Very open to discussion and feedback. I realize this approach bucks the typicals 'rails way'.

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [x] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [ ] New features have been documented, and the code is understandable and well commented
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation
