### PR TITLE
Admin param

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
   def context
     @context ||= Context.new(
       user: current_user,
-      hide_admin?: params[:admin] == 'false',
+      admin_param: params[:admin],
     )
   end
   helper_method :context

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
   around_action :switch_locale
 
   def set_admin_status
+    # FIXME: replace uses of @admin_status with pundit
     @admin_status = params[:admin] ? YAML.load(params[:admin]) : current_user&.admin_role? # allows admin user to simulate with param=false
   end
 
@@ -29,7 +30,10 @@ class ApplicationController < ActionController::Base
   end
 
   def context
-    @context ||= Context.new(user: current_user)
+    @context ||= Context.new(
+      user: current_user,
+      hide_admin?: params[:admin] == 'false',
+    )
   end
   helper_method :context
 

--- a/app/models/context.rb
+++ b/app/models/context.rb
@@ -1,4 +1,5 @@
 Context = Struct.new(
+  :hide_admin?,
   :system_settings,
   :user,
   keyword_init: true

--- a/app/models/context.rb
+++ b/app/models/context.rb
@@ -1,5 +1,5 @@
 Context = Struct.new(
-  :hide_admin?,
+  :admin_param,
   :system_settings,
   :user,
   keyword_init: true

--- a/app/models/context.rb
+++ b/app/models/context.rb
@@ -9,6 +9,10 @@ Context = Struct.new(
     self[:system_settings] ||= SystemSetting.current_settings
   end
 
+  def can_admin?
+    user && (user&.admin_role? || user&.sys_admin_role?) && admin_param != 'false'
+  end
+
   def to_h
     {
       system_settings: system_settings,

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,23 +1,21 @@
 class ApplicationPolicy
   module Utils
-    attr_reader :acting_user, :system_settings
+    attr_reader :acting_user, :admin_param, :system_settings
 
     def sys_admin?
-      acting_user && acting_user.sys_admin_role? && !hide_admin?
+      acting_user && acting_user.sys_admin_role? && admin_param != 'false'
     end
 
     def admin?
-      acting_user && acting_user.admin_role? && !hide_admin?
+      acting_user && acting_user.admin_role? && admin_param != 'false'
     end
 
     private
 
-    def hide_admin?; @hide_admin end
-
     # Allowing for context || user simplifies policy specs that don't use additional context.
     def extract(context)
       if context.respond_to?(:user)
-        [context.user, context.system_settings, context.hide_admin?]
+        [context.user, context.system_settings, context.admin_param]
       else
         [context, nil, nil]
       end
@@ -31,7 +29,7 @@ class ApplicationPolicy
     attr_reader :original_scope
 
     def initialize(context, original_scope)
-      @acting_user, @system_settings, @hide_admin = extract context
+      @acting_user, @system_settings, @admin_param = extract context
       @original_scope = original_scope
     end
 
@@ -45,7 +43,7 @@ class ApplicationPolicy
 
   # We've configured pundit to provide a user context (See https://github.com/varvet/pundit/#additional-context).
   def initialize(context, record)
-    @acting_user, @system_settings, @hide_admin = extract context
+    @acting_user, @system_settings, @admin_param = extract context
     @record = record
   end
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -10,6 +10,10 @@ class ApplicationPolicy
       acting_user && acting_user.admin_role? && admin_param != 'false'
     end
 
+    def can_admin?
+      admin? || sys_admin?
+    end
+
     private
 
     # Allowing for context || user simplifies policy specs that don't use additional context.

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -2,7 +2,7 @@ class PersonPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       case
-      when sys_admin? || admin?
+      when can_admin?
         original_scope.all
       when acting_user.present?
         original_scope.where(user_id: acting_user.id)
@@ -13,20 +13,15 @@ class PersonPolicy < ApplicationPolicy
   end
 
   def read?
-    person_attached_to_acting_user? ||
-      sys_admin? ||
-      admin?
+    person_attached_to_acting_user? || can_admin?
   end
 
   def change?
-    person_attached_to_acting_user? ||
-      sys_admin? ||
-      admin?
+    person_attached_to_acting_user? || can_admin?
   end
 
   def add?
-    person_attached_to_acting_user? ||
-      sys_admin?
+    person_attached_to_acting_user? || sys_admin?
   end
 
   def delete?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -2,7 +2,7 @@ class UserPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
       case
-      when sys_admin? || admin?
+      when can_admin?
         original_scope.all
       when acting_user.present?
         original_scope.where(id: acting_user.id)
@@ -13,15 +13,11 @@ class UserPolicy < ApplicationPolicy
   end
 
   def read?
-    target_user_is_acting_user? ||
-      sys_admin? ||
-      admin?
+    target_user_is_acting_user? || can_admin?
   end
 
   def change?
-    target_user_is_acting_user? ||
-      sys_admin? ||
-      admin?
+    target_user_is_acting_user? || can_admin?
   end
 
   def add?

--- a/spec/models/context_spec.rb
+++ b/spec/models/context_spec.rb
@@ -51,4 +51,66 @@ RSpec.describe Context do
         to eq ['positional', 'non_context', user, system_settings]
     end
   end
+
+  describe 'can_admin?' do
+    let(:context) { Context.new user: user, admin_param: admin_param }
+
+    subject { context.can_admin? }
+
+    context 'sysadmin' do
+      let(:user) { instance_double 'User', admin_role?: false, sys_admin_role?: true }
+
+      context '?admin not overriden' do
+        let(:admin_param) { nil }
+        it { is_expected.to be true }
+      end
+
+      context '?admin=false' do
+        let(:admin_param) { 'false' }
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'admin' do
+      let(:user) { instance_double 'User', admin_role?: true, sys_admin_role?: false }
+
+      context '?admin not overriden' do
+        let(:admin_param) { nil }
+        it { is_expected.to be true }
+      end
+
+      context '?admin=false' do
+        let(:admin_param) { 'false' }
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'neighbor' do
+      let(:user) { instance_double 'User', admin_role?: false, sys_admin_role?: false }
+
+      context '?admin not overriden' do
+        let(:admin_param) { nil }
+        it { is_expected.to be false }
+      end
+
+      context '?admin=false' do
+        let(:admin_param) { 'false' }
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'guest' do
+      let(:user) { nil }
+
+      context '?admin not overriden' do
+        let(:admin_param) { nil }
+        it { is_expected.to be_falsey }
+      end
+
+      context '?admin=false' do
+        let(:admin_param) { 'false' }
+        it { is_expected.to be_falsey }
+      end
+    end
+  end
 end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -31,20 +31,20 @@ RSpec.describe ApplicationPolicy do
   end
 
   describe 'hiding admin privileges' do
-    let(:context) { Context.new user: user, hide_admin?: hide_admin }
+    let(:context) { Context.new user: user, admin_param: admin_param }
 
     subject { policy.admin? }
 
     context 'for a user without admin privileges' do
       let(:user) { instance_double 'User', admin_role?: false }
 
-      context 'with admin role visible' do
-        let(:hide_admin) { false }
+      context 'without ?admin override' do
+        let(:admin_param) { nil }
         it { is_expected.to be false }
       end
 
-      context 'with admin role hidden' do
-        let(:hide_admin) { true }
+      context 'with ?admin=false' do
+        let(:admin_param) { 'false' }
         it { is_expected.to be false }
       end
     end
@@ -52,13 +52,13 @@ RSpec.describe ApplicationPolicy do
     context 'for a user with admin privileges' do
       let(:user) { instance_double 'User', admin_role?: true }
 
-      context 'with admin role visible' do
-        let(:hide_admin) { false }
+      context 'without ?admin override' do
+        let(:admin_param) { nil }
         it { is_expected.to be true }
       end
 
-      context 'with admin role hidden' do
-        let(:hide_admin) { true }
+      context 'with ?admin=false' do
+        let(:admin_param) { 'false' }
         it { is_expected.to be false }
       end
     end
@@ -68,13 +68,13 @@ RSpec.describe ApplicationPolicy do
 
       subject { policy.sys_admin? }
 
-      context 'with sysadmin role visible' do
-        let(:hide_admin) { false }
+      context 'without ?admin override' do
+        let(:admin_param) { nil }
         it { is_expected.to be true }
       end
 
-      context 'with sysadmin role hidden' do
-        let(:hide_admin) { true }
+      context 'with ?admin=false' do
+        let(:admin_param) { 'false' }
         it { is_expected.to be false }
       end
     end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+RSpec.describe ApplicationPolicy do
+  let(:system_settings) { instance_double 'SystemSetting' }
+  let(:user)            { instance_double 'User' }
+  let(:record)          { double :record }
+  let(:context)         { Context.new user: user, system_settings: system_settings }
+  let(:policy)          { ApplicationPolicy.new context, record }
+
+  describe 'initialization' do
+    it 'accepts Context and extracts its contents' do
+      expect(policy.acting_user).to be user
+      expect(policy.system_settings).to be system_settings
+    end
+
+    it 'also supports User instead of context' do
+      policy = ApplicationPolicy.new user, record
+      expect(policy.acting_user).to be user
+      expect(policy.system_settings).to be nil
+    end
+  end
+
+  describe 'default authorizations' do
+    it 'forbids all actions' do
+      expect(policy).to forbid_actions %i[show new create edit update destroy]
+    end
+
+    it 'fails if index action is checked' do
+      expect { policy.index? }.to raise_error StandardError
+    end
+  end
+
+  describe 'hiding admin privileges' do
+    let(:context) { Context.new user: user, hide_admin?: hide_admin }
+
+    subject { policy.admin? }
+
+    context 'for a user without admin privileges' do
+      let(:user) { instance_double 'User', admin_role?: false }
+
+      context 'with admin role visible' do
+        let(:hide_admin) { false }
+        it { is_expected.to be false }
+      end
+
+      context 'with admin role hidden' do
+        let(:hide_admin) { true }
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'for a user with admin privileges' do
+      let(:user) { instance_double 'User', admin_role?: true }
+
+      context 'with admin role visible' do
+        let(:hide_admin) { false }
+        it { is_expected.to be true }
+      end
+
+      context 'with admin role hidden' do
+        let(:hide_admin) { true }
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'for a user with sysadmin privileges' do
+      let(:user) { instance_double 'User', sys_admin_role?: true }
+
+      subject { policy.sys_admin? }
+
+      context 'with sysadmin role visible' do
+        let(:hide_admin) { false }
+        it { is_expected.to be true }
+      end
+
+      context 'with sysadmin role hidden' do
+        let(:hide_admin) { true }
+        it { is_expected.to be false }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Why
Rolls the `?admin=false` logic into `ApplicationPolicy` via `Context` introduced in #844.

This will allow us to eventually drop the `@admin_status` controller variable and cleanly rely on policies instead.

Also serves as an example of how `Context` is useful outside of the controller layer.

### What and How

1. Adds a `admin_param` flag to Context, passed in from `ApplicationController`
1. Extract and use this in `ApplicationPolicy` to allow for `admin?` and `sys_admin?` privileges to be overridden by sending `?admin=false`
1. Adds new `can_admin?` methods to `ApplicationPolicy` and `Context`. This method tests whether the user is an admin or sysadmin and knows about the `?admin=false` url param override.

### Testing
- [x] `app/policies/application_policy_spec.rb`.
- [x] `app/models/context_spec.rb`


### Next Steps
?

### Outstanding Questions, Concerns and Other Notes
?

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [x] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [x] New features have been documented, and the code is understandable and well commented
- [x] Entry added to CHANGELOG.md if appropriate
- [x] All outstanding questions and concerns have been resolved
- [x] Any next steps that seem like good ideas have been created as issues for future discussion & implementation
