### PR TITLE
Add task to give existing users admin privileges

### DIFF
--- a/lib/tasks/one_time.rake
+++ b/lib/tasks/one_time.rake
@@ -18,4 +18,10 @@ namespace :one_time do
       new_listings.each{ |new_listing| puts "+, #{new_listing.id}, #{new_listing.tag_list}" }
     end
   end
+
+  # FIXME: remove this after existing installations are upgraded
+  desc 'give existing users admin privileges'
+  task make_users_admins: :environment do
+    User.connection.update("update users set role = 'admin' where role = 'unset'")
+  end
 end


### PR DESCRIPTION
### Why
Our recently merged pundit work correctly restricts all admin pages to users with `admin` or `sys_admin` roles. However up until now, _any_ logged in user on existing installations was effectively an admin.

To match that reality, this PR adds a rake task to set the `admin` role on any existing user whose role is unset.

Fixes #852

### Testing
- [x] Test manually on local
- [ ] Test manually on mutual-aid-test

### Outstanding Questions, Concerns and Other Notes
@maebeale :
* Does this change make sense? Are there existing users who shouldn't be 'promoted' like this?
* Should we cut a release with this patch?
* Are there other installations where this task will need to be applied?

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [ ] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [x] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation

