### PR TITLE
Don't allow email override when claiming a contribution

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -11,7 +11,7 @@ class ClaimsController < ApplicationController
     end
     render locals: {
       contribution: contribution,
-      email: current_user.person&.email
+      email: current_user.email
     }
   end
 

--- a/app/interactions/claim_contribution.rb
+++ b/app/interactions/claim_contribution.rb
@@ -2,7 +2,6 @@
 
 class ClaimContribution < ActiveInteraction::Base
   string :peer_alias
-  string :email
   string :message
   record :contribution, class: Listing
   object :current_user, class: User
@@ -10,7 +9,7 @@ class ClaimContribution < ActiveInteraction::Base
   def execute
     # TODO: Need to handle race conditions to prevent creating multiple matches for same contribution
     ActiveRecord::Base.transaction do
-      add_person_details
+      ensure_person_record
       create_match_for_contribution
     end
     email_peer
@@ -18,21 +17,15 @@ class ClaimContribution < ActiveInteraction::Base
 
   private
 
-  def add_person_details
+  def ensure_person_record
     if current_user.person.blank?
-      Person.create!(new_person_params)
-    else
-      current_user.person.update!(email: email)
+      Person.create!(
+        name: peer_alias,
+        user: current_user,
+        email: current_user.email,
+        preferred_contact_method: ContactMethod.email,
+      )
     end
-  end
-
-  def new_person_params
-    {
-      name: peer_alias,
-      preferred_contact_method: ContactMethod.email,
-      user: current_user,
-      email: email,
-    }
   end
 
   def create_match_for_contribution

--- a/app/views/claims/new.html.erb
+++ b/app/views/claims/new.html.erb
@@ -1,18 +1,25 @@
 <section>
   <%= content_tag(:h1, "Claim This #{contribution.type}", class: "title") %>
   <div class="box">
-    <p class="mb-2">
-      Information you enter here will be delivered directly to the other party.
-      Remember to protect yourself and never provide sensitive personal info to
-      strangers.
+    <p class='block'>
+      The information you enter below will be sent to the other party.
+      Remember to protect yourself and never provide sensitive personal details to strangers.
     </p>
-        
+    <p>
+      Your email, <span class="is-size-5 is-family-monospace has-text-weight-bold"><%= email %></span>, will also be shared with them.
+    </p>
+    <p class='block'>
+      If you'd like to use a different email address, you can
+      <%= link_to 'change it here', edit_user_registration_path %>.
+    </p>
+
     <%= simple_form_for :claim, url: contribution_claims_path(contribution) do |f| %>
-      <%= f.input :peer_alias, as: :string, label: false, placeholder: "Alias or handle (do not use your real name here)", required: true %>
-      <%= f.input :email, as: :string, placeholder: "Add your email address", input_html: { value: email }, required: true  %>
-      <%= f.input :message, as: :text, required: true, placeholder: "Add some introductory text here. We do not share your contact information
-                                                     with the other party. Please only share information that you are comfortable
-                                                    sharing to facilitate this conversation.".squish %>
+      <%= f.input :peer_alias, as: :string, label: 'Alias', required: true,
+            placeholder: "Your alias, handle or name to include in the message" %>
+      <%= f.input :message, as: :text, required: true,
+            placeholder: "Add some introductory text here.
+            Please only share information that you are comfortable
+            sharing to facilitate this conversation.".squish %>
       <%= f.button :submit, "I understand, let's go!", class: "is-primary" %>
     <% end %>
   </div>

--- a/spec/interactions/claim_contribution_spec.rb
+++ b/spec/interactions/claim_contribution_spec.rb
@@ -7,45 +7,32 @@ RSpec.describe ClaimContribution do
   end
 
   let(:contribution) { create(:listing) }
-  let(:user) { create(:user)}
-  let(:peer_alias) { 'alias' }
-  let(:email) { 'user_email@example.com' }
+  let(:user) { create(:user, :with_person, email: 'user_email@example.com') }
 
-  subject(:interaction) { ClaimContribution.run!(
-    contribution: contribution.id,
-    current_user: user,
-    email: email,
-    peer_alias: peer_alias,
-    message: 'message',
-  )}
+  before do
+    ClaimContribution.run!(
+      contribution: contribution.id,
+      current_user: user,
+      peer_alias: 'alias',
+      message: 'message',
+    )
+  end
 
   it "matches contribution and sends an email to peer", :aggregate_failures do
-    allow_any_instance_of(ClaimContribution).to receive(:add_person_details)
-
-    interaction
-
     expect(MatchContribution).to have_received(:run!)
     expect(EmailPeer).to have_received(:run!)
   end
 
   context "when current user has no person record" do
+    let(:user) { create(:user, email: 'user_email@example.com', person: nil) }
+
     it "creates a person" do
-      interaction
-
-      expect(user.reload.person).to have_attributes(name: peer_alias,
-                                                    email: email,
-                                                    preferred_contact_method: ContactMethod.email,
-                                                    user: user)
-    end
-  end
-
-  context "when current has a person" do
-    let(:user) { create(:user, :with_person)}
-
-    it "updates the person email address" do
-      interaction
-
-      expect(user.reload.person).to have_attributes(email: email, user: user)
+      expect(user.reload.person).to have_attributes(
+        user: user,
+        email: user.email,
+        name: 'alias',
+        preferred_contact_method: ContactMethod.email,
+      )
     end
   end
 end


### PR DESCRIPTION
### Why
The current claim page allow the logged in user to provide an alternate email address to be sent to the contributor.
This opens the door to potential abuse or mistaken use because we would pass along the overriden email without verifying it.

This changes the implementation to use the logged in user's email, giving them a link to change it if they want to.
Since user account emails are verified, we gain a level of confidence that we're not passing along bad/incorrect emails.

### What
<img width="1311" alt="Screen Shot 2021-02-08 at 11 57 19 PM" src="https://user-images.githubusercontent.com/8330/107318249-57613c80-6a6a-11eb-9b11-53a2a0061de6.png">

### Testing
* Changed `spec/interactions/claim_contribution_spec.rb` to match new behavior.

### Next Steps
?

### Outstanding Questions, Concerns and Other Notes
?


### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [x] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [x] New features have been documented, and the code is understandable and well commented
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation
