### PR TITLE
changed service areas to be a many to many

### DIFF
--- a/app/controllers/community_resources_controller.rb
+++ b/app/controllers/community_resources_controller.rb
@@ -49,6 +49,10 @@ class CommunityResourcesController < ApplicationController
       @available_tags ||= Category.visible.pluck(:name) + community_resource&.tag_list || []
     end
 
+    def service_areas
+      @service_areas ||= ServiceArea.i18n.pluck(:name, :id) || []
+    end
+
     def determine_layout
       'without_navbar' unless context.system_settings.display_navbar?
     end
@@ -62,5 +66,5 @@ class CommunityResourcesController < ApplicationController
       end
     end
 
-    helper_method :available_tags, :community_resource
+    helper_method :available_tags, :community_resource, :service_areas
 end

--- a/app/models/community_resource.rb
+++ b/app/models/community_resource.rb
@@ -7,12 +7,13 @@ class CommunityResource < ApplicationRecord
 
   acts_as_taggable_on :tags
 
-  belongs_to :service_area, optional: true # TODO: - should this be optional???
   belongs_to :location, optional: true
   belongs_to :organization, optional: true # TODO: - should this be optional???
 
   has_many :matches_as_receiver
   has_many :matches_as_provider
+  has_many :community_resource_service_areas
+  has_many :service_areas, through: :community_resource_service_areas
 
   validates :name, :description, :publish_from, presence: true
 

--- a/app/models/community_resource_service_area.rb
+++ b/app/models/community_resource_service_area.rb
@@ -1,0 +1,4 @@
+class CommunityResourceServiceArea < ApplicationRecord
+  belongs_to :community_resource
+  belongs_to :service_area
+end

--- a/app/models/service_area.rb
+++ b/app/models/service_area.rb
@@ -16,6 +16,7 @@ class ServiceArea < ApplicationRecord
   has_many :listings
   has_many :people
   has_many :service_areas, inverse_of: :parent
+  has_many :community_resources, through: :community_resource_service_areas
 
   TYPES = %w[pod neighborhood region county city other]
 

--- a/app/policies/community_resource_policy.rb
+++ b/app/policies/community_resource_policy.rb
@@ -8,13 +8,14 @@ class CommunityResourcePolicy < ApplicationPolicy
     [
       :description,
       :facebook_url,
+      :location_id,
       :name,
       :phone,
       :publish_from,
       :publish_until,
-      :service_area_id,
       :website_url,
       :youtube_identifier,
+      service_area_ids: [],
       tag_list: [],
       organization_attributes: %i[id name _destroy],
     ]

--- a/app/views/community_resources/_form.html.erb
+++ b/app/views/community_resources/_form.html.erb
@@ -36,7 +36,7 @@
 
     <div class="field is-grouped">
       <%= f.input :tag_list, as: :check_boxes, collection: available_tags %>
-      <%= f.association :service_area, label: "Service area", label_method: "full_name" %>
+      <%= f.input :service_area_ids, label: "Service area", as: :check_boxes, collection: service_areas %>
       <%= f.association :location, label: "Address", label_method: "address" %>
     </div>
 

--- a/app/views/community_resources/index.html.erb
+++ b/app/views/community_resources/index.html.erb
@@ -16,7 +16,7 @@
           <%= link_to("More [*]", community_resource_path(community_resource)) if community_resource.description&.length.to_i > 100 %>
         </p>
         <p class="block has-text-weight-light">
-          <%= community_resource.phone %> <%= community_resource.service_area&.name %>
+          <%= community_resource.phone %> <%= community_resource.service_areas.map(&:name).to_sentence %>
         </p>
         <%= link_to("Website", community_resource.website_url, title: "Go to #{community_resource.website_url}",
                     class: "button is-link is-small") if community_resource.website_url.present? %>

--- a/app/views/community_resources/show.html.erb
+++ b/app/views/community_resources/show.html.erb
@@ -42,8 +42,8 @@
   </p>
 
   <p>
-    <strong>ServiceArea:</strong>
-    <%= community_resource.service_area&.name %>
+    <strong>Service areas:</strong>
+    <%= community_resource.service_areas.map(&:name).to_sentence %>
   </p>
 
   <p>

--- a/db/migrate/20210226012229_create_community_resource_service_area.rb
+++ b/db/migrate/20210226012229_create_community_resource_service_area.rb
@@ -1,0 +1,8 @@
+class CreateCommunityResourceServiceArea < ActiveRecord::Migration[6.0]
+  def change
+    create_table :community_resource_service_areas do |t|
+      t.references :community_resource, null: false, index: true, foreign_key: true
+      t.references :service_area, null: false, index: true, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_21_210339) do
+ActiveRecord::Schema.define(version: 2021_02_26_012229) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,13 @@ ActiveRecord::Schema.define(version: 2020_11_21_210339) do
     t.index ["delivery_method_id"], name: "index_communication_logs_on_delivery_method_id"
     t.index ["match_id"], name: "index_communication_logs_on_match_id"
     t.index ["person_id"], name: "index_communication_logs_on_person_id"
+  end
+
+  create_table "community_resource_service_areas", force: :cascade do |t|
+    t.bigint "community_resource_id", null: false
+    t.bigint "service_area_id", null: false
+    t.index ["community_resource_id"], name: "index_community_resource_service_areas_on_community_resource_id"
+    t.index ["service_area_id"], name: "index_community_resource_service_areas_on_service_area_id"
   end
 
   create_table "community_resources", force: :cascade do |t|
@@ -548,6 +555,8 @@ ActiveRecord::Schema.define(version: 2020_11_21_210339) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "communication_logs", "matches"
   add_foreign_key "communication_logs", "people"
+  add_foreign_key "community_resource_service_areas", "community_resources"
+  add_foreign_key "community_resource_service_areas", "service_areas"
   add_foreign_key "community_resources", "locations"
   add_foreign_key "community_resources", "organizations"
   add_foreign_key "community_resources", "service_areas"

--- a/spec/models/community_resource_spec.rb
+++ b/spec/models/community_resource_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe CommunityResource do
+  describe "community resource can have multiple service areas" do
+    it "has many service areas" do
+      should respond_to(:service_areas)
+    end
+    it "should not belong to a single service area" do
+      should_not respond_to(:service_area)
+    end
+  end 
+end

--- a/spec/requests/community_resources_spec.rb
+++ b/spec/requests/community_resources_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe '/community_resources', type: :request do
   }}}
 
   describe 'GET /community_resources' do
+    before { create_list :community_resource, 2 }
     it 'is publicly accessible' do
       get community_resources_path
       expect(response).to be_successful


### PR DESCRIPTION
Co-authored-by: maebeale <maebeale@gmail.com>
Co-authored-by: exbinary <exbinary@gmail.com>
Co-authored-by: connieh1 <connie2630a@gmail.com>

### Why
Community Resource can have multiple service areas so we changed the relationship to be a many to many by creating a CommunityResourceServiceArea as a join

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] All new features have been described in the pull request
- [ ] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [ ] New features have been documented, and the code is understandable and well commented
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation



