### PR TITLE
Seed files need to be updated to reflect latest changes, and to run without validation error.

### DIFF
--- a/app/models/importers/submission_response_importer.rb
+++ b/app/models/importers/submission_response_importer.rb
@@ -224,7 +224,12 @@ class Importers::SubmissionResponseImporter < Importers::BaseImporter
   end
 
   def create_organization_community_resource
-    CommunityResource.where(organization: @current_organization).first_or_create!(is_created_by_admin: true, name: 'PLACEHOLDER')
+    CommunityResource.where(organization: @current_organization).first_or_create!(
+      is_created_by_admin: true, 
+      name: 'PLACEHOLDER', 
+      description: 'DESCRIPTION PLACEHOLDER', 
+      publish_from: Date.current
+    )
   end
 
   def create_listings_data_from_category_questions(row, submission)

--- a/db/seeds/dev_seeds.rb
+++ b/db/seeds/dev_seeds.rb
@@ -87,7 +87,11 @@ end
 # organization
 org = Organization.where(name: "Diaper Bank").first_or_create!
 # community_resources
-CommunityResource.where(name: "this is diapers for you", description: "first come first serve", organization: org).first_or_create!
+CommunityResource.where(
+    name: "this is diapers for you", 
+    description: "first come first serve", 
+    organization: org
+  ).first_or_create!(publish_from: Faker::Time.between(from: Time.now - 20.days, to: DateTime.now))
 5.times do
   org = Organization.create!(name: Faker::Company.name)
   CommunityResource.create!(name: Faker::Lorem.words(number: (2..5).to_a.sample).join(" "),
@@ -97,7 +101,10 @@ CommunityResource.where(name: "this is diapers for you", description: "first com
 end
 
 # announcements
-Announcement.where(name: "Lansing urgent care are sharing free face masks", description: "Announcement announcement urgent care! Free masks!").first_or_create!
+Announcement.where(
+  name: "Lansing urgent care are sharing free face masks", 
+  description: "Announcement announcement urgent care! Free masks!",
+).first_or_create!(publish_from: Faker::Time.between(from: Time.now - 20.days, to: DateTime.now))
 5.times do
   Announcement.create!(name: Faker::Lorem.words(number: (2..5).to_a.sample).join(" "),
                        is_approved: [true,false].sample,


### PR DESCRIPTION
### Why
`publish_from` & `description` is now mandatory in `Announcement` & `CommunityResource` models. Therefore,
`bin/rake db:rebuild_and_seed_dev` gets validation error and fails to run.

### Pre-Merge Checklist
- [x] All tests are green
- [ ] Discuss with @maebeale & @exbinary 
