### PR TITLE
add claim email text for p2p

### DIFF
--- a/app/mailers/peer_to_peer_match_mailer.rb
+++ b/app/mailers/peer_to_peer_match_mailer.rb
@@ -2,15 +2,15 @@
 
 class PeerToPeerMatchMailer < ApplicationMailer
   def peer_to_peer_email(contribution, peer_alias:, message:)
-    peer_email_address = contribution.person.email
+    @peer_email_address = contribution.person.email
     email_subject = if contribution.ask?
                       "#{peer_alias} is offering to meet your ask"
                     elsif contribution.offer? # TODO: check if community resource when added
                       "#{peer_alias} would like to accept your offer"
                     end
 
-    mail(to: peer_email_address, subject: email_subject) do |format|
-      format.html { render locals: { message: message } }
+    mail(to: @peer_email_address, subject: email_subject) do |format|
+      format.html { render locals: { contribution: contribution, message: message } }
     end
   end
 end

--- a/app/views/peer_to_peer_match_mailer/peer_to_peer_email.html.erb
+++ b/app/views/peer_to_peer_match_mailer/peer_to_peer_email.html.erb
@@ -1,1 +1,12 @@
-<%= content_tag(:div, message) %>
+<div>
+  Good news! You have a match through <%= Organization.current_organization.name %>.
+  <br><br>
+  <%= contribution.person.name %> would like to connect with you about <%= contribution.tag_list.last %>, and they sent this message:
+  <br>
+  <%= content_tag(:div, message) %>
+  Please contact them within two days at <%= @peer_email_address %> to make arrangements.
+  <br><br>
+  If you aren’t able to connect, let us know so we can reinstate your <%= contribution.type %>.
+  <br><br>
+  Thanks for participating in Mutual Aid!
+</div>


### PR DESCRIPTION
Co-authored-by: connieh1 <connie2630a@gmail.com>
Co-authored-by: maebeale <maebeale@gmail.com>

### Why
Autoemails sent after someone Claims a Contribution needed some framing text

### What
We added a first pass of the Claim notification email template text

### Testing
N/A

### Next Steps
We should also consider sending an autoemail to the Claimer to confirm they did, in fact, Claim, and w note re that they should contact the mutual aid group if they don't hear back from their person within two days.

### Outstanding Questions, Concerns and Other Notes
We prob will want to get out of this being a hard-coded option (or have an override).