### PR TITLE
Community resource addresses

### DIFF
--- a/app/controllers/community_resources_controller.rb
+++ b/app/controllers/community_resources_controller.rb
@@ -17,7 +17,18 @@ class CommunityResourcesController < ApplicationController
   end
 
   def create
-    community_resource.assign_attributes permitted_attributes(community_resource)
+    location_params = params['community_resource']['location']
+
+    location = Location.where(
+      street_address: location_params['street_address'],
+      city: location_params['city'],
+      state: location_params['state'],
+      zip: location_params['zip'],
+      location_type_id: location_params['location_type_id']
+    ).first_or_create
+
+    community_resource.location = location
+    community_resource.update permitted_attributes(community_resource)
 
     if community_resource.save
       redirect_after_create

--- a/app/policies/community_resource_policy.rb
+++ b/app/policies/community_resource_policy.rb
@@ -16,7 +16,7 @@ class CommunityResourcePolicy < ApplicationPolicy
       :website_url,
       :youtube_identifier,
       tag_list: [],
-      organization_attributes: %i[id name _destroy],
+      organization_attributes: %i[id name _destroy]
     ]
       .tap do |permitted|
         permitted.push :is_approved if can_admin?

--- a/app/views/community_resources/_form.html.erb
+++ b/app/views/community_resources/_form.html.erb
@@ -38,11 +38,11 @@
       <%= f.input :tag_list, as: :check_boxes, collection: available_tags %>
       <%= f.association :service_area, label: "Service area", label_method: "full_name" %>
       <%= f.simple_fields_for :location do |location_form| %>
-        <%= location_form.input :street_address %>
-        <%= location_form.input :city %>
-        <%= location_form.input :state %>
-        <%= location_form.input :zip %>
-        <%= location_form.collection_select :location_type_id, LocationType.order(:name), :id, :name, include_blank: false %> 
+        <%= location_form.input :street_address, required: true %>
+        <%= location_form.input :city, required: true %>
+        <%= location_form.input :state, required: true %>
+        <%= location_form.input :zip, required: true %>
+        <%= location_form.collection_select :location_type_id, LocationType.order(:name), :id, :name, include_blank: false, required: true %> 
       <% end %>
     </div>
 

--- a/app/views/community_resources/_form.html.erb
+++ b/app/views/community_resources/_form.html.erb
@@ -37,7 +37,13 @@
     <div class="field is-grouped">
       <%= f.input :tag_list, as: :check_boxes, collection: available_tags %>
       <%= f.association :service_area, label: "Service area", label_method: "full_name" %>
-      <%= f.association :location, label: "Address", label_method: "address" %>
+      <%= f.simple_fields_for :location do |location_form| %>
+        <%= location_form.input :street_address %>
+        <%= location_form.input :city %>
+        <%= location_form.input :state %>
+        <%= location_form.input :zip %>
+        <%= location_form.collection_select :location_type_id, LocationType.order(:name), :id, :name, include_blank: false %> 
+      <% end %>
     </div>
 
     <div class="label is-expanded">Links</div>

--- a/app/views/community_resources/_form.html.erb
+++ b/app/views/community_resources/_form.html.erb
@@ -37,13 +37,15 @@
     <div class="field is-grouped">
       <%= f.input :tag_list, as: :check_boxes, collection: available_tags %>
       <%= f.association :service_area, label: "Service area", label_method: "full_name" %>
-      <%= f.simple_fields_for :location do |location_form| %>
-        <%= location_form.input :street_address, required: true %>
-        <%= location_form.input :city, required: true %>
-        <%= location_form.input :state, required: true %>
-        <%= location_form.input :zip, required: true %>
-        <%= location_form.collection_select :location_type_id, LocationType.order(:name), :id, :name, include_blank: false, required: true %> 
-      <% end %>
+      <div class="form-vertical">
+        <%= f.simple_fields_for :location do |location_form| %>
+          <%= location_form.input :street_address, required: true %>
+          <%= location_form.input :city, required: true %>
+          <%= location_form.input :state, required: true %>
+          <%= location_form.input :zip, required: true %>
+          <%= location_form.collection_select :location_type_id, LocationType.order(:name), :id, :name, include_blank: false, required: true %> 
+        <% end %>
+      </div>
     </div>
 
     <div class="label is-expanded">Links</div>

--- a/app/views/community_resources/_form.html.erb
+++ b/app/views/community_resources/_form.html.erb
@@ -41,8 +41,8 @@
         <%= f.simple_fields_for :location do |location_form| %>
           <%= location_form.input :street_address, required: true %>
           <%= location_form.input :city, required: true %>
-          <%= location_form.input :state, required: true %>
-          <%= location_form.input :zip, required: true %>
+          <%= location_form.input :state, required: true, maxlength: 2 %>
+          <%= location_form.input :zip, required: true, maxlength: 5 %>
           <%= location_form.collection_select :location_type_id, LocationType.order(:name), :id, :name, include_blank: false, required: true %> 
         <% end %>
       </div>

--- a/spec/requests/community_resources_spec.rb
+++ b/spec/requests/community_resources_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe '/community_resources', type: :request do
     context 'as a guest' do
       it 'succeeds' do
         expect { post community_resources_path, params: params }.to change(CommunityResource, :count).by 1
+        expect(Location.count).to eq(1)
         expect(response).to have_http_status :found
         expect(response.location).to match thank_you_path
       end

--- a/spec/requests/community_resources_spec.rb
+++ b/spec/requests/community_resources_spec.rb
@@ -58,7 +58,22 @@ RSpec.describe '/community_resources', type: :request do
     end
 
     context 'as a guest' do
-      it 'succeeds' do
+      it 'succeeds with a new location' do
+        expect { post community_resources_path, params: params }.to change(CommunityResource, :count).by 1
+        expect(Location.count).to eq(1)
+        expect(response).to have_http_status :found
+        expect(response.location).to match thank_you_path
+      end
+
+      it 'succeeds with an existing location' do
+        Location.new(
+          street_address: '123 Sesame Street',
+          city: 'Kings Park',
+          state: 'NY',
+          zip: '11754',
+          location_type_id: 1
+        )
+
         expect { post community_resources_path, params: params }.to change(CommunityResource, :count).by 1
         expect(Location.count).to eq(1)
         expect(response).to have_http_status :found

--- a/spec/requests/community_resources_spec.rb
+++ b/spec/requests/community_resources_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe '/community_resources', type: :request do
     description: 'Food for the rev!',
     publish_from: Date.current,
     organization_attributes: { name: 'Black Panther Party' },
+    location: { 
+      street_address: '123 Sesame Street',
+      city: 'Kings Park',
+      state: 'NY',
+      zip: '11754',
+      location_type_id: 1
+    }
   }}}
 
   describe 'GET /community_resources' do


### PR DESCRIPTION
### Why
closes #879 
- **Previously**: when user creates new Community Resource, they must select from dropdown of addresses of existing Locations
- **Now**: when user creates new Community Resource, they input an address
  - If Location with this address and type already exists, associates new Community Resource to this Location
  - If Location with this address and type _does not_ exist, creates new Location and associates new Community Resource to this Location

### What
Previously:
<img width="601" alt="Screen Shot 2021-03-09 at 7 56 46 PM" src="https://user-images.githubusercontent.com/34531014/110569312-96d68380-8111-11eb-9ecc-a978e6081e0f.png">

Now:
<img width="522" alt="Screen Shot 2021-03-09 at 7 53 54 PM" src="https://user-images.githubusercontent.com/34531014/110569046-30516580-8111-11eb-8902-b7d477f09b2f.png">

### How
- Used `first_or_create` to find or create a new Location

### Testing
- Updated existing request spec to add address params 

### Next Steps
- Refactor into form object design pattern + add unit tests
- Want to add more testing - ex: new location vs. location already existing

### Outstanding Questions, Concerns and Other Notes
- Do we want to collect any other Location data on this form? (ex: county, region, neighborhood)
- I couldn't figure out how to get label to display on Location Type form field (even when adding, label "Location Type"). I think this may have something to do with Simple Form? 
- Do we want address to be required field on new Community Resource form? 
  - aka do we want to require that a new Community Resource belongs to a Location? 

### Accessibility
N/A

### Security
This issue may need to be reviewed with accessibility and security in mind as I'm not very familiar with how I've impacted them 

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [ ] Security & accessibility have been considered
- [ ] Tests have been added, or an explanation has been given why the features cannot be tested
- [ ] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
