### PR TITLE
Set default mailer url for production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,6 +79,9 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  # Set default mailer url
+  config.action_mailer.default_url_options = { host: ENV['SYSTEM_HOST_NAME'] }
+
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write


### PR DESCRIPTION
### Why

Resolves bug with confirmation email is incorrectly linking to port 38076

### What

- [x] Set default mailer url for production

### How

We determined that this problem exists both locally and on production, the prod server is likely using a non-standard port (38076) and that is being added to the confirmation url by the following line in `config/application.rb`:

```
    config.action_mailer.default_url_options = {
      host: ENV['SYSTEM_HOST_NAME'],
      port: (ENV['PORT'].presence || 80).to_i,
    }
```

Setting the host without the port should resolve this issue.

### Testing

There are currently no tests for this as it is a devise method, but this should be tested in a demo environment to ensure it works as expected.

### Next Steps

Test in the demo environment

### Outstanding Questions, Concerns and Other Notes

None

### Accessibility

N/A

### Security
 
N/A

### Meta

N/A

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [ ] Security & accessibility have been considered
- [ ] Tests have been added, or an explanation has been given why the features cannot be tested
- [ ] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
