### PR TITLE
Fix local webpack compilation

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -2,6 +2,17 @@ const path = require('path')
 const { environment } = require('@rails/webpacker')
 const { VueLoaderPlugin } = require('vue-loader')
 
+// Override sass-loader implementation from deprecated node-sass to dart sass
+// https://mentalized.net/journal/2019/10/19/use-sass-modules-in-rails/
+// FIXME: remove this workaround when webpacker is upgraded to 6+
+environment
+  .loaders
+  .get('sass')
+  .use
+  .find(function(element) { return element.loader == 'sass-loader' })
+  .options
+  .implementation = require('sass')
+
 environment.plugins.prepend('VueLoaderPlugin', new VueLoaderPlugin())
 
 environment.loaders.prepend('vue', {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mapbox-gl-vue": "^2.0.4",
     "node-fetch": "^2.6.1",
     "null-loader": "^4.0.0",
+    "sass": "^1.32.8",
     "sass-loader": "8.0.2",
     "style-loader": "^1.1.4",
     "trix": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2556,6 +2556,21 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
+"chokidar@>=2.0.0 <4.0.0", chokidar@^3.4.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
+
 chokidar@^2.0.0, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -2574,21 +2589,6 @@ chokidar@^2.0.0, chokidar@^2.1.8:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
-
-chokidar@^3.4.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
-  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.5.0"
-  optionalDependencies:
-    fsevents "~2.3.1"
 
 chownr@^1.1.1:
   version "1.1.4"
@@ -8745,6 +8745,13 @@ sass-loader@8.0.2, sass-loader@^8.0.2:
     neo-async "^2.6.1"
     schema-utils "^2.6.1"
     semver "^6.3.0"
+
+sass@^1.32.8:
+  version "1.32.8"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.8.tgz#f16a9abd8dc530add8834e506878a2808c037bdc"
+  integrity sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==
+  dependencies:
+    chokidar ">=2.0.0 <4.0.0"
 
 sax@~1.2.4:
   version "1.2.4"


### PR DESCRIPTION
### Why
It appears that #897 broke webpack compilation locally (dev, test), at least on my machine, failing with:
`Error: Node Sass does not yet support your current environment: OS X 64-bit with Unsupported runtime (83)`

Some research led me to https://github.com/rails/webpacker/pull/2716 which has been merged into webpacker 6 but not backported into our current version.

### How
This changeset manually overrides the sass-loader implementation from `node-sass` to `sass`, as described [in this article](https://mentalized.net/journal/2019/10/19/use-sass-modules-in-rails/).

### Next Steps
Left a FIXME comment in `config/webpack/environment.js` to remove this workaround when we upgrade to webpacker 6.

### Outstanding Questions, Concerns and Other Notes
?

### Pre-Merge Checklist
- [x] Documentation and comments have been added to the codebase where required
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
