### PR TITLE
update wording on peer claim of contributions

### DIFF
--- a/app/views/contributions/_top_level_card.html.erb
+++ b/app/views/contributions/_top_level_card.html.erb
@@ -17,7 +17,7 @@
             <%= button_to "Claim This #{contribution.type}", new_contribution_claim_path(contribution), class: "button is-primary", method: :get %>
           <% else %>
             <button class="button is-primary" disabled="true">Claim This <%= contribution.type %></button>
-            <p class="is-6 is-italic">An ask without an email address cannot be claimed in peer-to-peer mode</p>
+            <p class="is-6 is-italic">This person has not yet entered contact information so that you can claim this contribution. You may need to check back later</p>
           <% end %>
         <% end %>
       </p>


### PR DESCRIPTION
### Why
I think our team usage of peer-to-peer is potentionally confusing to community members new to this application. That phrase means different things in different contexts, so I'd like to reduce potential confusion.

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] All new features have been described in the pull request
- [x] Security & accessibility have been considered
- [ ] High quality tests have been added, or an explanation has been given why the features cannot be tested
- [x] New features have been documented, and the code is understandable and well commented
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] All outstanding questions and concerns have been resolved
- [ ] Any next steps that seem like good ideas have been created as issues for future discussion & implementation

### What

I'm open to further changes to this if you'd like to improve the wording


### Testing
Mobile breakboint:

<img width="405" alt="Screen Shot 2021-02-23 at 10 01 51 AM" src="https://user-images.githubusercontent.com/3620291/108862733-832e0780-75be-11eb-9102-dd276750b377.png">

Wider breakpoint:

<img width="1250" alt="Screen Shot 2021-02-23 at 10 01 38 AM" src="https://user-images.githubusercontent.com/3620291/108862770-8b864280-75be-11eb-8f7c-e54688a11999.png">


### Next Steps
n/a


### Accessibility
This will hopefully improve legibility of this warning message
<!--
If this change will make any significant changes to either physical accessibility (eg, making the website work better with screenreaders) or technical accessibility (eg, making the website load faster for people with marginal internet), you should explain what they are, and highlight any issues or concerns you might have that haven't been resolved.
-->

### Security
This is a wording change that should have no security impact

I suppose we're now leaking a small amount of info about who has or has not entered their contact info. That is certainly a hard think to leverage in isolation, though