### PR TITLE
Workaround bug with multipart date in ActiveInteraction::Base#given?

### DIFF
--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -6,6 +6,14 @@ class BaseForm < ActiveInteraction::Base
   end
 
   def given_inputs
-    inputs.select{|key| given? key }
+    # FIXME: ActiveInteraction::Base#given? seems to have a bug recognizing multipart date params
+    raw_inputs = @_interaction_inputs
+    inputs.select do |key|
+      given?(key) || (
+        raw_inputs.key?(:"#{key}(1i)") &&
+        raw_inputs.key?(:"#{key}(2i)") &&
+        raw_inputs.key?(:"#{key}(3i)")
+      )
+    end
   end
 end

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe BaseForm do
+  describe '#given_inputs' do
+    let(:form) do
+      Class.new(BaseForm) {
+        string :string, default: nil
+        date   :date, default: nil
+
+        def execute
+          [inputs, given_inputs]
+        end
+
+        def self.model_name # needed for anonymous classes
+          ActiveModel::Name.new(self, nil, "BaseFormSpec")
+        end
+      }
+    end
+
+    let(:result) { form.build params }
+    let(:inputs) { result[0] }
+    let(:given_inputs) { result[1] }
+
+    context 'with no params given' do
+      let(:params) {{}}
+
+      it 'recognizes no params were given' do
+        expect(inputs).to eq(string: nil, date: nil)
+        expect(given_inputs).to be_empty
+      end
+    end
+
+    context 'with an explicitly nil param' do
+      let(:params) {{ date: nil }}
+
+      specify 'inputs show all params with defaults' do
+        expect(inputs).to eq(string: nil, date: nil)
+      end
+
+      specify 'given_inputs only show params that were explicitly given' do
+        expect(given_inputs).to eq(date: nil)
+      end
+    end
+
+    context 'with params given' do
+      let(:params) {{ string: 'a string', date: '2020-12-31' }}
+
+      it 'recognizes the given params' do
+        expect(inputs).to eq(string: 'a string', date: Date.new(2020, 12, 31))
+        expect(given_inputs).to eq inputs
+      end
+    end
+
+    context 'with a complete multi-part date param' do
+      let(:params) {{
+        'date(1i)' => '2020',
+        'date(2i)' => '12',
+        'date(3i)' => '31',
+      }}
+
+      it 'recognizes the multi-part date was given' do
+        expect(inputs).to eq(string: nil, date: Date.new(2020, 12, 31))
+        expect(given_inputs).to eq(date: Date.new(2020, 12, 31))
+      end
+    end
+
+    context 'with a partial multi-part date param' do
+      let(:params) {{
+        'date(1i)' => '2020',
+      }}
+
+      it 'ignores the date' do
+        expect(inputs).to eq(string: nil, date: nil)
+        expect(given_inputs).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Why
Discovered a small [bug](https://github.com/AaronLasseigne/active_interaction/issues/499) in `active_interaction` where multi-part date params such as those generated by `date_select` are correctly parsed but not recognized by the `given?` method. We rely on this method to filter params in our form objects -- in order to support partial updates, we filter out any params that were not given, only applying those that were.

### What
- [x] Includes a somewhat hackish workaround in our `given_inputs` method, pending a more appropriate fix upstream.
- [x] Also includes some specs around `BaseForm` to clearly demonstrate the issue and our overall use of `given?`.

### Next Steps
- [x] Create issue with `active_interaction` and offer to work on a PR.
- [ ] Upgrade once fix is merged upstream and cleanup our workaround.

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [x] Documentation and comments have been added to the codebase where required
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
