### PR TITLE
Improve locations on community resources

### DIFF
--- a/app/controllers/community_resources_controller.rb
+++ b/app/controllers/community_resources_controller.rb
@@ -17,20 +17,8 @@ class CommunityResourcesController < ApplicationController
   end
 
   def create
-    location_params = params['community_resource']['location']
-
-    location = Location.where(
-      street_address: location_params['street_address'],
-      city: location_params['city'],
-      state: location_params['state'],
-      zip: location_params['zip'],
-      location_type_id: location_params['location_type_id']
-    ).first_or_create
-
-    community_resource.location = location
-    community_resource.update permitted_attributes(community_resource)
-
-    if community_resource.save
+    @community_resource = authorize CommunityResourceForm.build params[:community_resource]
+    if @community_resource.save
       redirect_after_create
     else
       render :new

--- a/app/controllers/community_resources_controller.rb
+++ b/app/controllers/community_resources_controller.rb
@@ -17,8 +17,7 @@ class CommunityResourcesController < ApplicationController
   end
 
   def create
-    @community_resource = authorize CommunityResourceForm.build params[:community_resource]
-    if @community_resource.save
+    if build_community_resource.save
       redirect_after_create
     else
       render :new
@@ -26,7 +25,8 @@ class CommunityResourcesController < ApplicationController
   end
 
   def update
-    if community_resource.update(permitted_attributes(community_resource))
+    # todo now: this is now allowing `is_approved` to be set by any user
+    if build_community_resource.save
       redirect_to community_resources_path, notice: 'Community resource was successfully updated.'
     else
       render :edit
@@ -41,7 +41,11 @@ class CommunityResourcesController < ApplicationController
   private
 
     def community_resource
-      @community_resource ||= authorize(params[:id] ? CommunityResource.find(params[:id]) : CommunityResource.new)
+      @community_resource ||= authorize CommunityResource.find_or_new params[:id]
+    end
+
+    def build_community_resource
+      @community_resource = authorize CommunityResourceForm.build params[:community_resource].merge(id: params[:id])
     end
 
     def available_tags

--- a/app/controllers/community_resources_controller.rb
+++ b/app/controllers/community_resources_controller.rb
@@ -17,7 +17,8 @@ class CommunityResourcesController < ApplicationController
   end
 
   def create
-    if build_community_resource.save
+    @community_resource = authorize populate(CommunityResource.new)
+    if @community_resource.save
       redirect_after_create
     else
       render :new
@@ -25,8 +26,8 @@ class CommunityResourcesController < ApplicationController
   end
 
   def update
-    # todo now: this is now allowing `is_approved` to be set by any user
-    if build_community_resource.save
+    @community_resource = authorize populate(CommunityResource.find(params[:id]))
+    if @community_resource.save
       redirect_to community_resources_path, notice: 'Community resource was successfully updated.'
     else
       render :edit
@@ -40,12 +41,12 @@ class CommunityResourcesController < ApplicationController
 
   private
 
-    def community_resource
-      @community_resource ||= authorize CommunityResource.find_or_new params[:id]
+    def populate(community_resource)
+      CommunityResourceForm.build permitted_attributes(community_resource).merge(id: params[:id])
     end
 
-    def build_community_resource
-      @community_resource = authorize CommunityResourceForm.build params[:community_resource].merge(id: params[:id])
+    def community_resource
+      @community_resource ||= authorize CommunityResource.find_or_new params[:id]
     end
 
     def available_tags

--- a/app/forms/base_form.rb
+++ b/app/forms/base_form.rb
@@ -5,6 +5,21 @@ class BaseForm < ActiveInteraction::Base
     run! params
   end
 
+  def self.filter_keys(source = self)
+    hashes, others  = source.filters.partition { |_key, filter| filter.is_a? ActiveInteraction::HashFilter  }
+    arrays, scalars = others.partition         { |_key, filter| filter.is_a? ActiveInteraction::ArrayFilter }
+
+    result = scalars.map { |key, _| key }
+
+    return result if hashes.empty? && arrays.empty?
+    result << {}
+
+    append_array_keys_to(result.last, arrays)
+    append_nested_hash_keys_to(result.last, hashes)
+
+    result
+  end
+
   def given_inputs
     # FIXME: ActiveInteraction::Base#given? seems to have a bug recognizing multipart date params
     raw_inputs = @_interaction_inputs
@@ -16,4 +31,18 @@ class BaseForm < ActiveInteraction::Base
       )
     end
   end
+
+  private
+
+    def self.append_array_keys_to(collector, array_filters)
+      array_filters.each do |key, filter|
+        collector[key] = []
+      end
+    end
+
+    def self.append_nested_hash_keys_to(collector, hash_filters)
+      hash_filters.each do |key, filter|
+        collector[key] = filter.filters.empty? ? {} : filter_keys(filter)
+      end
+    end
 end

--- a/app/forms/community_resource_form.rb
+++ b/app/forms/community_resource_form.rb
@@ -5,7 +5,7 @@ class CommunityResourceForm < BaseForm
   string :name
   date   :publish_from
 
-  # todo now: why the difference between location and org? probably org uses accepts_nested_attributes?
+  # FIXME: consolidate the treatment of organization vs. location
   hash :organization_attributes do
     integer :id, default: nil
     string  :name
@@ -23,6 +23,7 @@ class CommunityResourceForm < BaseForm
     string  :youtube_identifier
     array   :service_area_ids
     array   :tag_list
+    boolean :is_approved
   end
 
   def execute

--- a/app/forms/community_resource_form.rb
+++ b/app/forms/community_resource_form.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CommunityResourceForm < BaseForm
+  string :description
+  string :name
+  date   :publish_from
+
+  hash :organization_attributes do
+    string :id, default: nil
+    string :name
+  end
+
+  with_options default: nil do
+    integer :id
+    string  :facebook_url
+    string  :location_id
+    string  :phone
+    date    :publish_until
+    string  :website_url
+    string  :youtube_identifier
+    array   :service_area_ids
+    array   :tag_list
+
+    # todo now: rename
+    hash :location, strip: false
+  end
+
+  def execute
+    CommunityResource.find_or_new(id).tap do |community_resource|
+      community_resource.attributes = given_inputs.merge(
+        location: LocationForm.build(location),
+      )
+    end
+  end
+end

--- a/app/forms/community_resource_form.rb
+++ b/app/forms/community_resource_form.rb
@@ -5,10 +5,13 @@ class CommunityResourceForm < BaseForm
   string :name
   date   :publish_from
 
+  # todo now: why the difference between location and org? probably org uses accepts_nested_attributes?
   hash :organization_attributes do
     string :id, default: nil
     string :name
   end
+
+  hash :location, strip: false, default: {}
 
   with_options default: nil do
     integer :id
@@ -20,9 +23,6 @@ class CommunityResourceForm < BaseForm
     string  :youtube_identifier
     array   :service_area_ids
     array   :tag_list
-
-    # todo now: rename
-    hash :location, strip: false
   end
 
   def execute

--- a/app/forms/community_resource_form.rb
+++ b/app/forms/community_resource_form.rb
@@ -7,8 +7,8 @@ class CommunityResourceForm < BaseForm
 
   # todo now: why the difference between location and org? probably org uses accepts_nested_attributes?
   hash :organization_attributes do
-    string :id, default: nil
-    string :name
+    integer :id, default: nil
+    string  :name
   end
 
   hash :location, strip: false, default: {}

--- a/app/models/community_resource.rb
+++ b/app/models/community_resource.rb
@@ -7,7 +7,7 @@ class CommunityResource < ApplicationRecord
 
   acts_as_taggable_on :tags
 
-  belongs_to :location, optional: true, validate: true # todo now: test this change
+  belongs_to :location, optional: true, validate: true
   belongs_to :organization, optional: true # FIXME: - should this be optional?
 
   has_many :matches_as_receiver

--- a/app/models/community_resource.rb
+++ b/app/models/community_resource.rb
@@ -7,7 +7,7 @@ class CommunityResource < ApplicationRecord
 
   acts_as_taggable_on :tags
 
-  belongs_to :location, optional: true, validate: true
+  belongs_to :location, optional: true, autosave: true
   belongs_to :organization, optional: true # FIXME: - should this be optional?
 
   has_many :matches_as_receiver

--- a/app/models/community_resource.rb
+++ b/app/models/community_resource.rb
@@ -7,8 +7,8 @@ class CommunityResource < ApplicationRecord
 
   acts_as_taggable_on :tags
 
-  belongs_to :location, optional: true
-  belongs_to :organization, optional: true # TODO: - should this be optional???
+  belongs_to :location, optional: true, validate: true # todo now: test this change
+  belongs_to :organization, optional: true # FIXME: - should this be optional?
 
   has_many :matches_as_receiver
   has_many :matches_as_provider

--- a/app/models/community_resource_service_area.rb
+++ b/app/models/community_resource_service_area.rb
@@ -2,3 +2,22 @@ class CommunityResourceServiceArea < ApplicationRecord
   belongs_to :community_resource
   belongs_to :service_area
 end
+
+# == Schema Information
+#
+# Table name: community_resource_service_areas
+#
+#  id                    :bigint           not null, primary key
+#  community_resource_id :bigint           not null
+#  service_area_id       :bigint           not null
+#
+# Indexes
+#
+#  index_community_resource_service_areas_on_community_resource_id  (community_resource_id)
+#  index_community_resource_service_areas_on_service_area_id        (service_area_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (community_resource_id => community_resources.id)
+#  fk_rails_...  (service_area_id => service_areas.id)
+#

--- a/app/policies/community_resource_policy.rb
+++ b/app/policies/community_resource_policy.rb
@@ -4,25 +4,10 @@ class CommunityResourcePolicy < ApplicationPolicy
   def change?; can_admin? end
   def delete?; can_admin? end
 
-  # todo now: do we need this now that we're using CommunityResourceForm
   def permitted_attributes
-    [
-      :description,
-      :facebook_url,
-      :location_id,
-      :name,
-      :phone,
-      :publish_from,
-      :publish_until,
-      :website_url,
-      :youtube_identifier,
-      service_area_ids: [],
-      tag_list: [],
-      organization_attributes: %i[id name _destroy]
-    ]
-      .tap do |permitted|
-        permitted.push :is_approved if can_admin?
-      end
+    CommunityResourceForm.filter_keys.tap do |keys|
+      keys.delete(:is_approved) unless can_admin?
+    end
   end
 
   class Scope < ApplicationPolicy::Scope

--- a/app/policies/community_resource_policy.rb
+++ b/app/policies/community_resource_policy.rb
@@ -4,6 +4,7 @@ class CommunityResourcePolicy < ApplicationPolicy
   def change?; can_admin? end
   def delete?; can_admin? end
 
+  # todo now: do we need this now that we're using CommunityResourceForm
   def permitted_attributes
     [
       :description,

--- a/app/views/community_resources/_form.html.erb
+++ b/app/views/community_resources/_form.html.erb
@@ -39,6 +39,7 @@
       <%= f.input :service_area_ids, label: "Service area", as: :check_boxes, collection: service_areas %>
       <div class="form-vertical">
         <%= f.simple_fields_for community_resource.location || Location.new, as: :location do |location_form| %>
+          <%= location_form.hidden_field :id %>
           <%= location_form.input :street_address %>
           <%= location_form.input :city %>
           <%= location_form.input :state, maxlength: 2 %>

--- a/app/views/community_resources/_form.html.erb
+++ b/app/views/community_resources/_form.html.erb
@@ -39,11 +39,11 @@
       <%= f.input :service_area_ids, label: "Service area", as: :check_boxes, collection: service_areas %>
       <div class="form-vertical">
         <%= f.simple_fields_for community_resource.location || Location.new, as: :location do |location_form| %>
-          <%= location_form.input :street_address, required: true %>
-          <%= location_form.input :city, required: true %>
-          <%= location_form.input :state, required: true, maxlength: 2 %>
-          <%= location_form.input :zip, required: true, maxlength: 5 %>
-          <%= location_form.input :location_type, as: :select, collection: LocationType.order(:name), required: true %>
+          <%= location_form.input :street_address %>
+          <%= location_form.input :city %>
+          <%= location_form.input :state, maxlength: 2 %>
+          <%= location_form.input :zip, maxlength: 5 %>
+          <%= location_form.input :location_type, as: :select, collection: LocationType.order(:name), required: false %>
         <% end %>
       </div>
     </div>

--- a/app/views/community_resources/_form.html.erb
+++ b/app/views/community_resources/_form.html.erb
@@ -38,12 +38,12 @@
       <%= f.input :tag_list, as: :check_boxes, collection: available_tags %>
       <%= f.input :service_area_ids, label: "Service area", as: :check_boxes, collection: service_areas %>
       <div class="form-vertical">
-        <%= f.simple_fields_for :location do |location_form| %>
+        <%= f.simple_fields_for community_resource.location || Location.new, as: :location do |location_form| %>
           <%= location_form.input :street_address, required: true %>
           <%= location_form.input :city, required: true %>
           <%= location_form.input :state, required: true, maxlength: 2 %>
           <%= location_form.input :zip, required: true, maxlength: 5 %>
-          <%= location_form.input :location_type_id, as: :select, collection: LocationType.order(:name), required: true %>
+          <%= location_form.input :location_type, as: :select, collection: LocationType.order(:name), required: true %>
         <% end %>
       </div>
     </div>

--- a/app/views/community_resources/_form.html.erb
+++ b/app/views/community_resources/_form.html.erb
@@ -43,7 +43,7 @@
           <%= location_form.input :city, required: true %>
           <%= location_form.input :state, required: true, maxlength: 2 %>
           <%= location_form.input :zip, required: true, maxlength: 5 %>
-          <%= location_form.collection_select :location_type_id, LocationType.order(:name), :id, :name, include_blank: false, required: true %> 
+          <%= location_form.input :location_type_id, as: :select, collection: LocationType.order(:name), required: true %>
         <% end %>
       </div>
     </div>

--- a/app/views/community_resources/_form.html.erb
+++ b/app/views/community_resources/_form.html.erb
@@ -44,7 +44,8 @@
           <%= location_form.input :city %>
           <%= location_form.input :state, maxlength: 2 %>
           <%= location_form.input :zip, maxlength: 5 %>
-          <%= location_form.input :location_type, as: :select, collection: LocationType.order(:name), required: false %>
+          <%= location_form.input :location_type_id, as: :select, collection: LocationType.order(:name), required: false,
+                                  input_html: {name: 'community_resource[location][location_type]'} %>
         <% end %>
       </div>
     </div>

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 RSpec.describe BaseForm do
   describe '#given_inputs' do
-    let(:form) do
-      Class.new(BaseForm) {
+    let(:form_class) do
+      Class.new(BaseForm) do
         string :string, default: nil
         date   :date, default: nil
 
@@ -16,10 +16,10 @@ RSpec.describe BaseForm do
         def self.model_name # needed for anonymous classes
           ActiveModel::Name.new(self, nil, "BaseFormSpec")
         end
-      }
+      end
     end
 
-    let(:result) { form.build params }
+    let(:result) { form_class.build params }
     let(:inputs) { result[0] }
     let(:given_inputs) { result[1] }
 
@@ -76,5 +76,37 @@ RSpec.describe BaseForm do
         expect(given_inputs).to be_empty
       end
     end
+  end
+
+  describe '.filter_keys' do
+    let(:form_class) do
+      Class.new(BaseForm) do
+        array :array
+        date  :date
+        hash  :raw_hash, strip: false
+        hash  :nested_hash do
+          date :nested_date
+          hash :doubly_nested_hash do
+            integer :id
+          end
+        end
+
+        def self.model_name # needed for anonymous classes
+          ActiveModel::Name.new(self, nil, "BaseFormSpec")
+        end
+      end
+    end
+
+    subject(:keys) { form_class.filter_keys }
+
+    it { is_expected.to eq [
+      :date,
+      array: [],
+      raw_hash: {},
+      nested_hash: [
+        :nested_date,
+        doubly_nested_hash: [:id],
+      ],
+    ]}
   end
 end

--- a/spec/forms/community_resource_form_spec.rb
+++ b/spec/forms/community_resource_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CommunityResourceForm do
     publish_from: '1969-01-01',
     location: {
       city: 'Oakland',
-      location_type: LocationType.first,
+      location_type: LocationType.first.id,
     },
     organization_attributes: {
       name: 'Black Panther Party',
@@ -31,8 +31,13 @@ RSpec.describe CommunityResourceForm do
       expect(community_resource.location.city).to eq 'Oakland'
     end
 
-    context 'when location is omitted' do
-      before { params.delete :location }
+    context 'when location params are empty' do
+      before do
+        params[:location] = {
+          city: '',
+          location_type: '',
+        }
+      end
 
       it 'does not populate an associated location' do
         expect(community_resource.location).to be nil
@@ -83,9 +88,12 @@ RSpec.describe CommunityResourceForm do
 
     let(:community_resource) { CommunityResourceForm.build update_params }
 
-    it 'applies updated attributes' do
+    it 'applies updated attributes to the community resource' do
       expect(community_resource.name).to eq 'new name'
       expect(community_resource.description).to eq 'new description'
+    end
+
+    it 'applies updated attributes to nested models' do
       expect(community_resource.location.city).to eq 'new city'
       expect(community_resource.organization.name).to eq 'new org'
     end

--- a/spec/forms/community_resource_form_spec.rb
+++ b/spec/forms/community_resource_form_spec.rb
@@ -46,7 +46,9 @@ RSpec.describe CommunityResourceForm do
 
     describe 'on save' do
       it 'persists the new community resource with new associated records' do
-        expect { community_resource.save! }.to(
+        expect {
+          community_resource.save!
+        }.to(
           change(CommunityResource, :count).by(1).and(
           change(Organization, :count).by(1)).and(
           change(Location, :count).by(1))
@@ -63,7 +65,7 @@ RSpec.describe CommunityResourceForm do
         end
 
         it 'gathers errors from nested models' do
-          expect(community_resource.errors.keys).to include(:description, :location, :"organization.name")
+          expect(community_resource.errors.keys).to include(:description, :"location.location_type", :"organization.name")
         end
       end
     end
@@ -78,11 +80,13 @@ RSpec.describe CommunityResourceForm do
       description: 'new description',
       publish_from: existing.publish_from.to_s,
       location: {
+        id: existing.location.id,
         city: 'new city',
         location_type: existing.location.location_type_id,
       },
       organization_attributes: {
-        name: 'new org'
+        id: existing.organization.id,
+        name: 'new org',
       },
     }}
 
@@ -96,6 +100,27 @@ RSpec.describe CommunityResourceForm do
     it 'applies updated attributes to nested models' do
       expect(community_resource.location.city).to eq 'new city'
       expect(community_resource.organization.name).to eq 'new org'
+    end
+
+    describe 'on save' do
+      it 'does not create any new records' do
+        expect {
+          community_resource.save!
+        }.to(
+          change(CommunityResource, :count).by(0).and(
+          change(Organization, :count).by(0)).and(
+          change(Location, :count).by(0))
+        )
+      end
+
+      it 'persists updated values correctly' do
+        community_resource.save!
+        existing.reload
+        expect(existing.name).to eq 'new name'
+        expect(existing.description).to eq 'new description'
+        expect(existing.location.city).to eq 'new city'
+        expect(existing.organization.name).to eq 'new org'
+      end
     end
   end
 end

--- a/spec/forms/community_resource_form_spec.rb
+++ b/spec/forms/community_resource_form_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe CommunityResourceForm do
+  let(:params) {{
+    name: 'Free breakfast program',
+    description: 'Feed the people!',
+    publish_from: '1969-01-01',
+    location: {
+      city: 'Oakland',
+      location_type: LocationType.first,
+    },
+    organization_attributes: {
+      name: 'Black Panther Party',
+    },
+  }}
+
+  describe 'creating a new community resource' do
+    let(:community_resource) { CommunityResourceForm.build params }
+
+    it 'populates a new community resource' do
+      expect(community_resource.name).to eq 'Free breakfast program'
+      expect(community_resource.description).to eq 'Feed the people!'
+      expect(community_resource.publish_from).to eq Date.new(1969, 1, 1)
+    end
+
+    it 'populates an associated organization' do
+      expect(community_resource.organization.name).to eq 'Black Panther Party'
+    end
+
+    it 'populates an associated location' do
+      expect(community_resource.location.city).to eq 'Oakland'
+    end
+
+    context 'when location is omitted' do
+      before { params.delete :location }
+
+      it 'does not populate an associated location' do
+        expect(community_resource.location).to be nil
+      end
+    end
+
+    describe 'on save' do
+      it 'persists the new community resource with new associated records' do
+        expect { community_resource.save! }.to(
+          change(CommunityResource, :count).by(1).and(
+          change(Organization, :count).by(1)).and(
+          change(Location, :count).by(1))
+        )
+      end
+
+      context 'with validation errors' do
+        before do
+          params[:description] = ''
+          params[:location].delete :location_type
+          params[:organization_attributes][:name] = ''
+
+          community_resource.save
+        end
+
+        it 'gathers errors from nested models' do
+          expect(community_resource.errors.keys).to include(:description, :location, :"organization.name")
+        end
+      end
+    end
+  end
+
+  describe 'updating an existing community resource' do
+    let!(:existing) { CommunityResourceForm.build(params).tap{|o| o.save! } }
+
+    let(:update_params) {{
+      id: existing.id,
+      name: 'new name',
+      description: 'new description',
+      publish_from: existing.publish_from.to_s,
+      location: {
+        city: 'new city',
+        location_type: existing.location.location_type_id,
+      },
+      organization_attributes: {
+        name: 'new org'
+      },
+    }}
+
+    let(:community_resource) { CommunityResourceForm.build update_params }
+
+    it 'applies updated attributes' do
+      expect(community_resource.name).to eq 'new name'
+      expect(community_resource.description).to eq 'new description'
+      expect(community_resource.location.city).to eq 'new city'
+      expect(community_resource.organization.name).to eq 'new org'
+    end
+  end
+end

--- a/spec/requests/community_resources_spec.rb
+++ b/spec/requests/community_resources_spec.rb
@@ -6,14 +6,16 @@ RSpec.describe '/community_resources', type: :request do
   let(:params) {{ community_resource: {
     name: 'Free Breakfast Program',
     description: 'Food for the rev!',
-    publish_from: Date.current,
+    'publish_from(1i)' => '2020',
+    'publish_from(2i)' => '12',
+    'publish_from(3i)' => '31',
     organization_attributes: { name: 'Black Panther Party' },
     location: {
       street_address: '123 Sesame Street',
       city: 'Kings Park',
       state: 'NY',
       zip: '11754',
-      location_type_id: 1
+      location_type: 1,
     }
   }}}
 
@@ -40,11 +42,18 @@ RSpec.describe '/community_resources', type: :request do
   end
 
   describe 'PUT /community_resources' do
+    it 'creates a new community resource and location' do
+      expect { post community_resources_path, params: params }.to(
+        change(CommunityResource, :count).by(1).and(
+        change(Location, :count).by(1)
+      ))
+    end
+
     context 'as an admin' do
       before { sign_in create :user, :admin }
 
-      it 'succeeds and redirects to /community_resources' do
-        expect { post community_resources_path, params: params }.to change(CommunityResource, :count).by 1
+      it 'redirects to /community_resources' do
+        post community_resources_path, params: params
         expect(response).to have_http_status :found
         expect(response.location).to match community_resources_path
       end
@@ -61,36 +70,8 @@ RSpec.describe '/community_resources', type: :request do
     context 'as a guest' do
       it 'redirects to the thank you page' do
         post community_resources_path, params: params
-
         expect(response).to have_http_status :found
         expect(response.location).to match thank_you_path
-      end
-
-      it 'creates a new community resource and location' do
-        expect { post community_resources_path, params: params }.to(
-          change(CommunityResource, :count).by(1).and(
-          change(Location, :count).by(1)
-        ))
-      end
-
-      context 'when a matching location already exists' do
-        let(:location_attrs) {{
-          street_address: '42 existing location',
-          location_type_id: 1,
-        }}
-
-        before do
-          Location.create! location_attrs
-        end
-
-        it 'creates a new community resource using the existing location' do
-          params[:community_resource][:location] = location_attrs
-
-          expect { post community_resources_path, params: params }.to(
-            change(CommunityResource, :count).by(1).and(
-            change(Location, :count).by(0)
-          ))
-        end
       end
     end
   end


### PR DESCRIPTION
### Why
Primarily makes location fields optional on the `CommunityResource` form and ensures a 1-1 relationship betweeen CommunityResources and their Locations. Also introduces some new tools and patterns for working with Form objects.

### What

- [x] Drop location lookup/reuse in `CommunityResourcesController#create`. The current implementation attempts to find a matching `Location` record and reuse it. In discussion with @maebeale and @h-m-m, decided to instead treat our `locations` table as merely an extraction of columns that would otherwise be duplicated in multiple host tables. The `Location` model and table give us a way to extract logic and columns, but do _not_ represent anything more semantic meaning. In particular, location records are not intended to be unique or reused; each one is completely owned and tied 1 to 1 with a single host record.
- [x] Make location fields optional
- [x] Introduce a `CommunityResourceForm` to simplify the controller and ease unit testing. The form is reused in the create and updated actions.
- [x] Introduce a `BaseForm.filter_keys` method to eliminate duplication between form objects and pundit policies. Both need a list of expected attributes: the form defines these as filters and the policy in `permitted_attributes`. `filter_keys` is designed to be called by the policy and generates a strong_params compatible list of all filters defined on the form.

### Testing
- [x] Tried to cover important scenarios in `community_resource_form_spec.rb`.
- [x] Moved some existing/obsolete specs out of `requests/community_resource.rb`.
- [x] Added specs to `base_form_spec.rb` for new `.filter_keys` functionality.

### Next Steps
- [x] Need to clean up one todo: `CommunityResourceForm` handles its nested `organization` and `location` differently. One uses `accepts_nested_attributes` while the other uses a nested form object. Would be good to be consistent with one or the other -- marked as a #FIXME.
- [x] Needs some more manual testing.

### Outstanding Questions, Concerns and Other Notes
?

### Security
- [x] Needed to ensure the changes here didn't allow non-admins to toggle whether a CR is approved.

### Pre-Merge Checklist
- [x] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [x] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
