### PR TITLE
Free specs from seeding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
           command: |
             set -euxo pipefail
             bundle config path .bundle
-            bundle exec rails db:setup
+            bundle exec rails db:create
             bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml
   yarn_tests:
     description: "Run the Mocha test suite"

--- a/app/controllers/asks_controller.rb
+++ b/app/controllers/asks_controller.rb
@@ -14,7 +14,12 @@ class AsksController < PublicController
   def create
     submission = SubmissionForm.build submission_params
     if submission.save
-      EmailNewSubmission.run! submission: submission, user: current_user, system_setting: context.system_settings
+      EmailNewSubmission.run!(
+        submission: submission,
+        user: current_user,
+        system_setting: context.system_settings
+        organization: Organization.instance_owner
+      )
       redirect_to thank_you_path, notice: 'Ask was successfully created.'
     else
       render_form(submission)

--- a/app/controllers/asks_controller.rb
+++ b/app/controllers/asks_controller.rb
@@ -14,7 +14,7 @@ class AsksController < PublicController
   def create
     submission = SubmissionForm.build submission_params
     if submission.save
-      EmailNewSubmission.run! submission: submission, user: current_user
+      EmailNewSubmission.run! submission: submission, user: current_user, system_setting: context.system_settings
       redirect_to thank_you_path, notice: 'Ask was successfully created.'
     else
       render_form(submission)

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -14,7 +14,12 @@ class OffersController < PublicController
   def create
     submission = SubmissionForm.build submission_params
     if submission.save
-      EmailNewSubmission.run! submission: submission, user: current_user, system_setting: context.system_settings
+      EmailNewSubmission.run!(
+        submission: submission,
+        user: current_user,
+        system_setting: context.system_settings,
+        organization: Organization.instance_owner,
+      )
       redirect_to thank_you_path, notice: 'Offer was successfully created.'
     else
       render_form(submission)

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -14,7 +14,7 @@ class OffersController < PublicController
   def create
     submission = SubmissionForm.build submission_params
     if submission.save
-      EmailNewSubmission.run! submission: submission, user: current_user
+      EmailNewSubmission.run! submission: submission, user: current_user, system_setting: context.system_settings
       redirect_to thank_you_path, notice: 'Offer was successfully created.'
     else
       render_form(submission)

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -13,12 +13,10 @@ class PublicPagesController < PublicController
   end
 
   def landing_page
-    @json = {
-      landing_page_text_what: HtmlSanitizer.new(@system_setting.landing_page_text_what).sanitize,
-      landing_page_text_who: HtmlSanitizer.new(@system_setting.landing_page_text_who).sanitize,
-      landing_page_text_how: HtmlSanitizer.new(@system_setting.landing_page_text_how).sanitize,
-      organization_name: Organization.instance_owner.name,
-    }.to_json
+    @json = GenerateLandingPageJson.run!(
+      system_setting: context.system_settings,
+      organization: Organization.instance_owner,
+    )
   end
 
   def version

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -22,7 +22,12 @@ class SubmissionsController < AdminController
     @submission = Submission.new(submission_params)
 
     if @submission.save
-      EmailNewSubmission.run! submission: @submission, user: current_user, system_setting: context.system_settings
+      EmailNewSubmission.run!(
+        submission: @submission,
+        user: current_user,
+        system_setting: context.system_settings,
+        organization: Organization.instance_owner,
+      )
       redirect_to submissions_path, notice: 'Submission successfully created.'
     else
       set_form_dropdowns

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -22,7 +22,7 @@ class SubmissionsController < AdminController
     @submission = Submission.new(submission_params)
 
     if @submission.save
-      EmailNewSubmission.run! submission: @submission, user: current_user
+      EmailNewSubmission.run! submission: @submission, user: current_user, system_setting: context.system_settings
       redirect_to submissions_path, notice: 'Submission successfully created.'
     else
       set_form_dropdowns

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,4 +73,9 @@ module ApplicationHelper
       urgency_level_text
     end
   end
+
+  def site_logo_url
+    # There should always be a current org, but being defensive here helps simplify tests
+    Organization.instance_owner&.logo_url.presence || asset_pack_path('media/images/logo.png')
+  end
 end

--- a/app/interactions/email_new_submission.rb
+++ b/app/interactions/email_new_submission.rb
@@ -3,10 +3,15 @@
 class EmailNewSubmission < ActiveInteraction::Base
   object :submission
   object :system_setting
+  object :organization
   object :user, default: nil
 
   def execute
-    email = SubmissionMailer.new_submission_confirmation_email(submission, system_setting)
+    email = SubmissionMailer.new_submission_confirmation_email(
+      submission: submission,
+      system_setting: system_setting,
+      organization: organization,
+    )
 
     status = Messenger.new(email, 'new_submission_confirmation_email').deliver_now
 

--- a/app/interactions/email_new_submission.rb
+++ b/app/interactions/email_new_submission.rb
@@ -2,10 +2,11 @@
 
 class EmailNewSubmission < ActiveInteraction::Base
   object :submission
+  object :system_setting
   object :user, default: nil
 
   def execute
-    email = SubmissionMailer.new_submission_confirmation_email(submission)
+    email = SubmissionMailer.new_submission_confirmation_email(submission, system_setting)
 
     status = Messenger.new(email, 'new_submission_confirmation_email').deliver_now
 

--- a/app/interactions/email_peer.rb
+++ b/app/interactions/email_peer.rb
@@ -4,11 +4,13 @@ class EmailPeer < ActiveInteraction::Base
   string :peer_alias
   string :message
   object :contribution, class: Listing
+  object :organization
   object :user
 
   def execute
     peer_to_peer_email = PeerToPeerMatchMailer.peer_to_peer_email(
       contribution,
+      organization: organization,
       peer_alias: peer_alias,
       message: message,
     )

--- a/app/interactions/generate_landing_page_json.rb
+++ b/app/interactions/generate_landing_page_json.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class GenerateLandingPageJson < ActiveInteraction::Base
+  object :system_setting
+  object :organization
+
+  def execute
+    {
+      landing_page_text_what: sanitize(system_setting.landing_page_text_what),
+      landing_page_text_who: sanitize(system_setting.landing_page_text_who),
+      landing_page_text_how: sanitize(system_setting.landing_page_text_how),
+      organization_name: organization.name,
+    }.to_json
+  end
+
+  private
+
+    def sanitize string
+      HtmlSanitizer.new(string).sanitize
+    end
+end

--- a/app/javascript/components/NavBar.vue
+++ b/app/javascript/components/NavBar.vue
@@ -2,7 +2,7 @@
   <b-navbar fixed-top transparent shadow>
     <template slot="brand">
       <b-navbar-item href="/">
-        <img :src="logoUrl || $options.defaultLogo" alt="mutual-aid-app logo" height="300px" />
+        <img :src="logoUrl" alt="mutual-aid-app logo" height="300px" />
       </b-navbar-item>
     </template>
 
@@ -36,7 +36,6 @@
 </template>
 
 <script>
-import logo from 'images/logo.png'
 import {DeleteButton} from 'components/forms'
 import {FeedbackButton} from 'components/forms'
 
@@ -54,7 +53,5 @@ export default {
       return this.visibleButtons.includes(button)
     },
   },
-
-  defaultLogo: logo,
 }
 </script>

--- a/app/mailers/peer_to_peer_match_mailer.rb
+++ b/app/mailers/peer_to_peer_match_mailer.rb
@@ -1,16 +1,24 @@
 # frozen_string_literal: true
 
 class PeerToPeerMatchMailer < ApplicationMailer
-  def peer_to_peer_email(contribution, peer_alias:, message:)
-    @peer_email_address = contribution.person.email
+  def peer_to_peer_email(contribution, peer_alias:, message:, organization:)
+    peer_email_address = contribution.person.email
+
     email_subject = if contribution.ask?
                       "#{peer_alias} is offering to meet your ask"
                     elsif contribution.offer? # TODO: check if community resource when added
                       "#{peer_alias} would like to accept your offer"
                     end
 
-    mail(to: @peer_email_address, subject: email_subject) do |format|
-      format.html { render locals: { contribution: contribution, message: message } }
+    mail(to: peer_email_address, subject: email_subject) do |format|
+      format.html do
+        render locals: {
+          contribution: contribution,
+          message: message,
+          organization: organization,
+          peer_email_address: peer_email_address,
+        }
+      end
     end
   end
 end

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -5,12 +5,13 @@ include ApplicationHelper  # TODO: better way to solve this?
 
 # TODO: could do with specs
 class SubmissionMailer < ApplicationMailer
-  def new_submission_confirmation_email(submission, system_setting=nil)
+  def new_submission_confirmation_email(submission, system_setting)
     @submission = submission
+    @system_setting = system_setting
 
+    # FIXME: inject instance_owner similar to system_setting
     instance_owner = Organization.instance_owner
     @organization_name = instance_owner.name
-    @system_setting = system_setting || SystemSetting.first
 
     @form_name = @submission.form_name
     if @form_name.downcase.include?('ask')
@@ -23,8 +24,6 @@ class SubmissionMailer < ApplicationMailer
 
     @person = @submission.person
     @locale = @person.preferred_locale || 'en'
-
-    @system_settings = SystemSetting.current_settings
 
     system_email = ENV['SYSTEM_EMAIL']
     smtp_from_email = ENV['SMTP_FROM_EMAIL']

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -5,21 +5,18 @@ include ApplicationHelper  # TODO: better way to solve this?
 
 # TODO: could do with specs
 class SubmissionMailer < ApplicationMailer
-  def new_submission_confirmation_email(submission, system_setting)
+  def new_submission_confirmation_email(submission:, system_setting:, organization:)
     @submission = submission
     @system_setting = system_setting
-
-    # FIXME: inject instance_owner similar to system_setting
-    instance_owner = Organization.instance_owner
-    @organization_name = instance_owner.name
+    @organization_name = organization.name
 
     @form_name = @submission.form_name
     if @form_name.downcase.include?('ask')
-      @form_contact = instance_owner.ask_form_contact
+      @form_contact = organization.ask_form_contact
     elsif @form_name.downcase.include?('offer')
-      @form_contact = instance_owner.offer_form_contact
+      @form_contact = organization.offer_form_contact
     elsif @form_name.downcase.include?('community_resource')
-      @form_contact = instance_owner.community_resources_contact
+      @form_contact = organization.community_resources_contact
     end
 
     @person = @submission.person
@@ -29,7 +26,7 @@ class SubmissionMailer < ApplicationMailer
     smtp_from_email = ENV['SMTP_FROM_EMAIL']
     contact_email = @form_contact&.person&.email || "#{smtp_from_email}"
     contact_name =  @form_contact&.person&.name || @form_contact&.name || contact_email
-    contact_email_with_name = %("#{contact_name} (#{instance_owner.name})" <#{contact_email}>)
+    contact_email_with_name = %("#{contact_name} (#{organization.name})" <#{contact_email}>)
     bcc_emails = [contact_email, smtp_from_email, system_email].uniq.join('; ')
 
     @subject = "#{ENV["SYSTEM_APP_NAME"]} confirmation (" + @person.updated_at.to_date.to_s + ')'

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <div class="row text-center login-screen" style="vertical-align:middle;">
   <div class="col-md-6 col-md-offset-2 logo-image text-center">
-    <%= render 'shared/organization_logo' %>
+    <%= image_tag site_logo_url, width: 300, alt: 'Logo' %>
   </div>
   <div class="col-md-4 text-center">
     <h2>Sign up</h2>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <div class="columns text-center login-screen" style="vertical-align:middle;">
   <div class="column is-half logo-image text-center">
-    <%= render 'shared/organization_logo' %>
+    <%= image_tag site_logo_url, width: 300, alt: 'Logo' %>
   </div>
   <div class="column is-half text-center">
     <div class="section">

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -2,7 +2,7 @@
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     EntryPoints.navBar('#navBar', <%= raw({
-      logoUrl: Organization.instance_owner.present? ? Organization.instance_owner.logo_url : "",
+      logoUrl: site_logo_url,
       visibleButtons: policy(:nav_bar).visible_buttons,
     }.to_json) %>)
   })

--- a/app/views/peer_to_peer_match_mailer/peer_to_peer_email.html.erb
+++ b/app/views/peer_to_peer_match_mailer/peer_to_peer_email.html.erb
@@ -1,5 +1,5 @@
 <div>
-  Good news! You have a match through <%= Organization.instance_owner.name %>.
+  Good news! You have a match through <%= organization.name %>.
   <br><br>
   <%= contribution.person.name %> would like to connect with you about <%= contribution.tag_list.last %>, and they sent this message:
   <br>

--- a/app/views/shared/_organization_logo.html.erb
+++ b/app/views/shared/_organization_logo.html.erb
@@ -1,5 +1,0 @@
-<% if Organization.instance_owner.logo_url.present? %>
-  <%= image_tag Organization.instance_owner.logo_url, width: 300, alt: 'Logo' %>
-<% else %>
-  <%= image_pack_tag 'media/images/logo.png', width: 300, alt: 'Logo' %>
-<% end %>

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -1,15 +1,10 @@
 ## Running specs
-Running `bin/test` will run ruby tests (rspec) and then the js tests (mocha) if all the rspec tests pass
+Running `bin/test` will run ruby tests (rspec) and then the js tests (mocha via mochapack) if all the rspec tests pass
 
 To run front end tests and back end tests individually:
 
-* Vue.js front end tests: `yarn test` or `yarn test -w` (mocha and chai are included in the `package.json` )
-* Rails front end and back end tests: `bin/rspec` (rspec is included in the Gemfile)
-
-Note that we currently rely on seeding in some of our backend specs, so before running `rspec`, first seed the test database:
-```
-bin/rake db:seed RAILS_ENV=test
-```
+* Front end: `yarn test` or `yarn test -w` (to watch for changes and rerun)
+* Back end: `bin/rspec` or `rerun bin/rspec spec/some/dir/or_spec.rb` (to watch for changes and rerun)
 
 ## Request specs
 When writing rspec tests within the spec/request directory, you can use `Warden::Test:Helpers`

--- a/spec/forms/community_resource_form_spec.rb
+++ b/spec/forms/community_resource_form_spec.rb
@@ -1,13 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe CommunityResourceForm do
+  let!(:location_type) { create :location_type }
   let(:params) {{
     name: 'Free breakfast program',
     description: 'Feed the people!',
     publish_from: '1969-01-01',
     location: {
       city: 'Oakland',
-      location_type: LocationType.first.id,
+      location_type: location_type.id,
     },
     organization_attributes: {
       name: 'Black Panther Party',

--- a/spec/interactions/email_new_submission_spec.rb
+++ b/spec/interactions/email_new_submission_spec.rb
@@ -1,10 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe EmailNewSubmission do
-  let(:user)       { create :user }
-  let(:submission) { create :submission }
+  let(:user)           { create :user }
+  let(:submission)     { create :submission }
+  let(:system_setting) { build  :system_setting }
 
-  subject(:interaction) { EmailNewSubmission.run! submission: submission, user: user }
+  subject(:interaction) do
+    EmailNewSubmission.run! submission: submission, user: user, system_setting: system_setting
+  end
 
   let(:last_email) { ActionMailer::Base.deliveries.last }
   let(:last_log)   { CommunicationLog.last }

--- a/spec/interactions/email_new_submission_spec.rb
+++ b/spec/interactions/email_new_submission_spec.rb
@@ -4,9 +4,15 @@ RSpec.describe EmailNewSubmission do
   let(:user)           { create :user }
   let(:submission)     { create :submission }
   let(:system_setting) { build  :system_setting }
+  let(:organization)   { build  :organization }
 
   subject(:interaction) do
-    EmailNewSubmission.run! submission: submission, user: user, system_setting: system_setting
+    EmailNewSubmission.run!(
+      submission: submission,
+      user: user,
+      system_setting: system_setting,
+      organization: organization,
+    )
   end
 
   let(:last_email) { ActionMailer::Base.deliveries.last }

--- a/spec/interactions/email_peer_spec.rb
+++ b/spec/interactions/email_peer_spec.rb
@@ -1,12 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe EmailPeer do
-  let(:user)       { create(:user, :with_person) }
+  let(:user)         { create(:user, :with_person) }
   let(:contribution) { create :listing }
-  let(:peer_alias) { "peer_alias" }
-  let(:message) { "contribution P2P message" }
+  let(:organization) { build :organization }
+  let(:peer_alias)   { "peer_alias" }
+  let(:message)      { "contribution P2P message" }
 
-  subject(:interaction) { EmailPeer.run!(contribution: contribution, user: user, peer_alias: peer_alias, message: message) }
+  subject(:interaction) do
+    EmailPeer.run!(
+      contribution: contribution,
+      organization: organization,
+      user: user,
+      peer_alias: peer_alias,
+      message: message
+    )
+  end
 
   let(:last_email) { ActionMailer::Base.deliveries.last }
   let(:last_log)   { CommunicationLog.last }

--- a/spec/interactions/generate_landing_page_json_spec.rb
+++ b/spec/interactions/generate_landing_page_json_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe GenerateLandingPageJson do
+  let(:system_setting) do
+    build :system_setting, {
+      landing_page_text_what: 'what?',
+      landing_page_text_who: 'who?',
+      landing_page_text_how: 'how?',
+    }
+  end
+
+  let(:organization) { build :organization, name: 'org_name' }
+
+  subject(:json) do
+    GenerateLandingPageJson.run! system_setting: system_setting, organization: organization
+  end
+
+  it 'pulls landing page text from system settings' do
+    expect(JSON.parse(json)).to include(
+      "landing_page_text_what" => 'what?',
+      "landing_page_text_who" =>  'who?',
+      "landing_page_text_how" =>  'how?',
+    )
+  end
+end
+

--- a/spec/requests/community_resources_spec.rb
+++ b/spec/requests/community_resources_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe '/community_resources', type: :request do
+  let!(:location_type) { create :location_type }
   let(:community_resource) { create :community_resource }
 
   let(:params) {{ community_resource: {
@@ -15,7 +16,7 @@ RSpec.describe '/community_resources', type: :request do
       city: 'Kings Park',
       state: 'NY',
       zip: '11754',
-      location_type: 1,
+      location_type: location_type.id,
     }
   }}}
 

--- a/spec/requests/public_pages_spec.rb
+++ b/spec/requests/public_pages_spec.rb
@@ -1,36 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe '/', type: :request do
-  it 'has landing_page_text_what populated from system_setting' do
-    expected_what_text = Faker::Lorem.sentence
-    new_system_setting = build(:system_setting, landing_page_text_what: expected_what_text)
-    expect(SystemSetting).to receive(:first).and_return new_system_setting
-
-    get '/'
-
-    # TODO: assert
-  end
-
-  it 'has landing_page_text_who populated from system_setting' do
-    expected_who_text = Faker::Lorem.sentence
-    new_system_setting = build(:system_setting, landing_page_text_who: expected_who_text)
-    expect(SystemSetting).to receive(:first).and_return new_system_setting
-
-    get '/'
-
-    # TODO: assert
-  end
-
-  it 'has landing_page_text_how populated from system_setting' do
-    expected_how_text = Faker::Lorem.sentence
-    new_system_setting = build(:system_setting, landing_page_text_how: expected_how_text)
-    expect(SystemSetting).to receive(:first).and_return new_system_setting
-
-    get '/'
-
-    # TODO: assert
-  end
-
   describe 'GET /version' do
     let(:version) { JSON.parse(File.read(Rails.root.join('package.json'))).dig('version') }
 


### PR DESCRIPTION
### Why
Our ruby specs currently depend on the test database being seeded, which is non-standard and surprising, particularly for new contributors.

### What, How
- [x] Consolidate `logo_url` logic into a new helper method and make it defensive in case the DB doesn't have an `instance_owner`.
    - [x] Moves existing logic out of `shared/_organization_logo` and `NavBar.vue`.
- [x] Extract `GenerateLandingPageJson` interactor out of `PublicPagesController.landing_page` to ease testing.
- [x] Create `LocationType` in a couple of specs instead of relying on one having been seeded.
- [x] Thread `SystemSetting` into `SubmissionMailer` so it can be injected easily in specs.
- [x] Thread `Organization` into `EmailNewSubmission` and `EmailPeer` interactors, and the corresponding mailers (`SubmissionMailer`, `PeerToPeerMatchMailer`)
- [x] Drop seeding from CircleCI rspec task.

### Testing
Relies on existing specs and some manual testing of nav bar, login and signup pages.

### Next Steps
- [ ] Probably worth exploring whether `Organization.instance_owner` should live in `Context`, similar to `SystemSetting.current_settings`.
- [x] Remove mention of needing to seed in docs.

### Outstanding Questions, Concerns and Other Notes
Note this is built on top of #926 which renamed `Organization.current_organization` to `.instance_owner`. However the changes here aren't really dependent on that particular change.


### Pre-Merge Checklist
- [x] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [x] Documentation and comments have been added to the codebase where required
- [x] Entry to CHANGELOG.md not necessary
- [x] Outstanding questions and concerns have been resolved
- [x] Any next steps have been turned into Issues or Discussions as appropriate
