### PR TITLE
make Announcement show page like a card

### DIFF
--- a/app/presenters/announcement_presenter.rb
+++ b/app/presenters/announcement_presenter.rb
@@ -1,0 +1,8 @@
+class AnnouncementPresenter < SimpleDelegator
+  def expires_on
+    return "This announcement does not expire." unless publish_until
+
+    expire_text = self.publish_until > Time.current ? "Expires" : "Expired"
+    "#{expire_text} on #{I18n.l(publish_until, format: :long_month)}"
+  end
+end

--- a/app/views/announcements/show.html.erb
+++ b/app/views/announcements/show.html.erb
@@ -1,31 +1,26 @@
-<%= render "layouts/view_header", resource: announcement %>
-
+<% announcement_presenter = AnnouncementPresenter.new(announcement) %>
 <p id="notice"><%= notice %></p>
+<div class="card">
+  <header class="card-header">
+    <p class="card-header-title title is-3">
+      <%= announcement_presenter.name %>
+      <% if policy(announcement).change? %>
+        <%= link_to 'Edit', edit_announcement_path(announcement), class: "button is-primary ml-1" %>
+      <% end %>
+    </p>
+  </header>
+  <div class="card-content">
+    <div class="content">
+      <p>
+        <%= announcement_presenter.description %>
+      </p>
 
-<div class="section-detail">
-  <p>
-    <strong>Name:</strong>
-    <%= announcement.name %>
-  </p>
-
-  <p>
-    <strong>Description:</strong>
-    <%= announcement.description %>
-  </p>
-
-  <p>
-    <strong>Display date start:</strong>
-    <%= announcement.publish_from %>
-  </p>
-
-  <p>
-    <strong>Display date end:</strong>
-    <%= announcement.publish_until %>
-  </p>
-
-  <% if policy(announcement).change? %>
-    <%= link_to 'Edit', edit_announcement_path(announcement) %> |
-  <% end %>
-  <%= link_to 'Back', announcements_path %>
+      <p>
+        <small><em><%= announcement_presenter.expires_on %></em></small>
+      </p>
+    </div>
+  </div>
+  <div class="card-footer">
+    <%= link_to 'Back', announcements_path, class: "button is-info ml-1 mt-1 mb-1" %>
+  </div>
 </div>
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,3 +53,6 @@ en:
       zero: Match Feedback
   pundit:
     default: 'You cannot perform this action.'
+  date:
+    formats:
+      long_month: "%B %d, %Y"


### PR DESCRIPTION
### Issue
#885 

### Why
- Make the Announcement show page like a card, make it fancy

### What
- Add some Bulma style for Announcement show page

### Screenshots
![image](https://user-images.githubusercontent.com/42526152/114089316-31c4a800-98e0-11eb-96c7-3de0cff967ef.png)

--Without edit permission:
![image](https://user-images.githubusercontent.com/42526152/114089414-515bd080-98e0-11eb-8d3b-d629d4ef5605.png)
