### PR TITLE
Force Warden.test_reset! after request specs

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -11,8 +11,6 @@ When writing rspec tests within the spec/request directory, you can use `Warden:
 which give you access to the `login_as(user, :scope => :user)` method, as well as the `logout` method.
 You use `FactoryBot.create(:user)` before the `login_as` method and pass it in as the required resource variable.
 
-BE SURE to include the line `after { Warden.test_reset! }` after the `before do` block with the `login_as` method within it. This prevents unexpected state data of the user from hanging around and causing errors.
-
 ## Test app on heroku
 We have a heroku install for testing!
 [http://mutual-aid-demo.herokuapp.com/](http://mutual-aid-demo.herokuapp.com/)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,4 +75,9 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # https://github.com/wardencommunity/warden/wiki/Testing#requirements
+  config.after type: :request do
+    Warden.test_reset!
+  end
 end


### PR DESCRIPTION
Happened to notice this in `doc/testing.md`:
> BE SURE to include the line `after { Warden.test_reset! }` after the `before do` block with the `login_as` method within it. This prevents unexpected state data of the user from hanging around and causing errors.

I'm pretty sure none of us are doing that 😅 !

This PR adds an `after` hook to `rails_helper.rb` that automatically resets `warden` for request specs.
