### PR TITLE
Rubocop rules related to spaces

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Metrics:
   # Disabled in Standard by default
   Enabled: true
 
+Layout/ExtraSpacing:
+  AllowForAlignment: true
+
 Style/StringLiterals:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -412,14 +412,6 @@ Layout/SpaceInsideArrayLiteralBrackets:
 Layout/SpaceInsideBlockBraces:
   Enabled: false
 
-# Offense count: 203
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.
-# SupportedStyles: space, no_space, compact
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceInsideHashLiteralBraces:
-  Enabled: false
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -343,45 +343,6 @@ Layout/ParameterAlignment:
     - 'app/helpers/application_helper.rb'
     - 'app/helpers/communication_log_buttons.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-Layout/SpaceAfterComma:
-  Exclude:
-    - 'app/controllers/service_areas_controller.rb'
-    - 'app/models/importers/user_importer.rb'
-    - 'db/seeds/dev_seeds.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: AllowForAlignment, EnforcedStyleForExponentOperator.
-# SupportedStylesForExponentOperator: space, no_space
-Layout/SpaceAroundOperators:
-  Exclude:
-    - 'db/seeds/dev_seeds.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Layout/SpaceBeforeComment:
-  Exclude:
-    - 'app/models/user.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/SpaceInsideParens:
-  Exclude:
-    - 'app/helpers/communication_log_buttons.rb'
-    - 'db/seeds/dev_seeds.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/SpaceInsideStringInterpolation:
-  Exclude:
-    - 'db/scripts/tuple_counts.rb'
-
 # Offense count: 11
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -404,14 +404,6 @@ Layout/SpaceInsideArrayLiteralBrackets:
     - 'db/migrate/20201121210339_create_action_text_tables.action_text.rb'
     - 'db/seeds.rb'
 
-# Offense count: 56
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces, SpaceBeforeBlockParameters.
-# SupportedStyles: space, no_space
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceInsideBlockBraces:
-  Enabled: false
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -201,12 +201,6 @@ Layout/EndAlignment:
     - 'app/mailers/peer_to_peer_match_mailer.rb'
     - 'config/initializers/simple_form_bulma.rb'
 
-# Offense count: 247
-# Cop supports --auto-correct.
-# Configuration parameters: AllowForAlignment, AllowBeforeTrailingComments, ForceEqualSignAlignment.
-Layout/ExtraSpacing:
-  Enabled: false
-
 # Offense count: 24
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -351,21 +351,6 @@ Layout/SpaceAfterComma:
     - 'app/models/importers/user_importer.rb'
     - 'db/seeds/dev_seeds.rb'
 
-# Offense count: 20
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/SpaceAroundEqualsInParameterDefault:
-  Exclude:
-    - 'app/helpers/application_helper.rb'
-    - 'app/helpers/index_action_buttons.rb'
-    - 'app/models/communication_log.rb'
-    - 'app/models/history_log.rb'
-    - 'app/models/importers/base_importer.rb'
-    - 'app/models/importers/submission_response_importer.rb'
-    - 'app/models/importers/user_importer.rb'
-    - 'app/models/service_area.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: AllowForAlignment, EnforcedStyleForExponentOperator.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -374,14 +374,6 @@ Layout/SpaceAroundOperators:
   Exclude:
     - 'db/seeds/dev_seeds.rb'
 
-# Offense count: 37
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.
-# SupportedStyles: space, no_space
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceBeforeBlockBraces:
-  Enabled: false
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Layout/SpaceBeforeComment:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -380,16 +380,6 @@ Layout/SpaceBeforeComment:
   Exclude:
     - 'app/models/user.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: require_no_space, require_space
-Layout/SpaceInLambdaLiteral:
-  Exclude:
-    - 'app/models/contact_method.rb'
-    - 'app/models/match.rb'
-    - 'app/models/service_area.rb'
-
 # Offense count: 15
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBrackets.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -380,20 +380,6 @@ Layout/SpaceBeforeComment:
   Exclude:
     - 'app/models/user.rb'
 
-# Offense count: 15
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBrackets.
-# SupportedStyles: space, no_space, compact
-# SupportedStylesForEmptyBrackets: space, no_space
-Layout/SpaceInsideArrayLiteralBrackets:
-  Exclude:
-    - 'app/controllers/matches_controller.rb'
-    - 'app/models/software_feedback.rb'
-    - 'config/environments/production.rb'
-    - 'db/migrate/20201121210338_create_active_storage_tables.active_storage.rb'
-    - 'db/migrate/20201121210339_create_action_text_tables.action_text.rb'
-    - 'db/seeds.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,7 @@ class ApplicationController < ActionController::Base
   end
 
   def default_url_options
-    { locale: I18n.locale }
+    {locale: I18n.locale}
   end
 
   def context

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -51,7 +51,7 @@ class CategoriesController < AdminController
     end
 
     def set_form_dropdowns
-      @parent_categories = Category.where.not(id: @category.id).order(:name).map{ |t| [t.name.titleize, t.id] }
+      @parent_categories = Category.where.not(id: @category.id).order(:name).map { |t| [t.name.titleize, t.id] }
     end
 
     def category_params

--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -54,8 +54,8 @@ class ContributionsController < ApplicationController
   def filter_params
     return {} unless allowed_params&.to_h.any?
 
-    allowed_params.to_h.filter { |key, _v| BrowseFilter::ALLOWED_PARAMS.keys.include? key}.tap do |hash|
-      hash.each_key { |key| hash[key] = hash[key].keys}
+    allowed_params.to_h.filter { |key, _v| BrowseFilter::ALLOWED_PARAMS.keys.include? key }.tap do |hash|
+      hash.each_key { |key| hash[key] = hash[key].keys }
     end
   end
 

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -13,7 +13,7 @@ class ListingsController < AdminController
     end
 
     # follow_up_status filter
-    @match_statuses = Listing::MATCH_STATUSES.map {|s| [s.titleize, s]}
+    @match_statuses = Listing::MATCH_STATUSES.map { |s| [s.titleize, s] }
     if params[:match_status].present?
       @listings = @listings.match_status(params[:match_status])
     end
@@ -121,8 +121,8 @@ class ListingsController < AdminController
 
     def filter_params
       return Hash.new unless allowed_params && allowed_params.to_h.any?
-      allowed_params.to_h.filter { |key, _v| BrowseFilter::ALLOWED_PARAMS.keys.include? key}.tap do |hash|
-        hash.keys.each { |key| hash[key] = hash[key].keys}
+      allowed_params.to_h.filter { |key, _v| BrowseFilter::ALLOWED_PARAMS.keys.include? key }.tap do |hash|
+        hash.keys.each { |key| hash[key] = hash[key].keys }
       end
     end
 end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -45,7 +45,7 @@ class ListingsController < AdminController
 
   def match
     listing_type = @listing.type
-    match_polymorphic_params = listing_type == Ask ? { receiver: @listing } : { provider: @listing }
+    match_polymorphic_params = listing_type == Ask ? {receiver: @listing} : {provider: @listing}
     @match = Match.new
     @match.update(match_polymorphic_params)
     @possible_providers = Listing.offers # TODO: - get this to be a filtered list -- need to add logic by which to match

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -13,13 +13,13 @@ class ListingsController < AdminController
     end
 
     # follow_up_status filter
-    @match_statuses = Listing::MATCH_STATUSES.map{|s| [s.titleize, s]}
+    @match_statuses = Listing::MATCH_STATUSES.map {|s| [s.titleize, s]}
     if params[:match_status].present?
       @listings = @listings.match_status(params[:match_status])
     end
 
     # person_id filter
-    @people = Person.all.map{ |p| [p.name, p.id] }.sort_by(&:first)
+    @people = Person.all.map { |p| [p.name, p.id] }.sort_by(&:first)
     if params[:person_id].present?
       person_id = Person.find(params[:person_id])&.id # verify the person is in the db
       @listings = @listings.person_id(person_id)

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -29,7 +29,7 @@ class LocationsController < AdminController
     end
 
     # person_id filter
-    @people = Person.all.map{ |p| [p.name, p.id] }.sort_by(&:first)
+    @people = Person.all.map { |p| [p.name, p.id] }.sort_by(&:first)
     if params[:person_id].present?
       person_id = Person.find(params[:person_id])&.id # verify the person is in the db
       @locations = @locations.person_id(person_id)
@@ -79,7 +79,7 @@ class LocationsController < AdminController
   end
 
   def set_form_dropdowns
-    @service_areas = ServiceArea.all.map{ |t| [t.full_name, t.id] }.sort_by(&:first)
+    @service_areas = ServiceArea.all.map { |t| [t.full_name, t.id] }.sort_by(&:first)
   end
 
   def location_params

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -7,7 +7,7 @@ class MatchesController < AdminController
     @matches = Match.status(params[:status] || 'all').order(updated_at: :desc)
 
     # follow_up_status filter
-    @statuses = Match::STATUSES.map {|s| [s.titleize, s]}
+    @statuses = Match::STATUSES.map { |s| [s.titleize, s] }
     if params[:follow_up_status].present?
       @matches = @matches.follow_up_status(params[:follow_up_status])
     end
@@ -101,7 +101,7 @@ class MatchesController < AdminController
       else
 
       end
-      @statuses = Match::STATUSES.map {|s| [s.titleize, s]}
+      @statuses = Match::STATUSES.map { |s| [s.titleize, s] }
 
       @communication_logs = CommunicationLog.where(match: @match)
 

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -92,12 +92,12 @@ class MatchesController < AdminController
         @provider = Listing.where(type: type, id: params[:provider_id]).first
       end
 
-      @matchable_asks = Ask.matchable.map { |a| [ a.name_and_match_history.html_safe, a.id ] }.sort_by(&:first)
-      @matchable_offers = Offer.matchable.map { |o| [ o.name_and_match_history.html_safe, o.id] }.sort_by(&:first)
+      @matchable_asks = Ask.matchable.map { |a| [a.name_and_match_history.html_safe, a.id] }.sort_by(&:first)
+      @matchable_offers = Offer.matchable.map { |o| [o.name_and_match_history.html_safe, o.id] }.sort_by(&:first)
 
       if @match.receiver_id && @match.provider_id
-        @matched_asks = (@matchable_asks + [[@match.receiver&.name_and_match_history.html_safe, @match.receiver&.id ]]).sort_by(&:first)
-        @matched_offers = (@matchable_offers + [[@match.provider&.name_and_match_history.html_safe, @match.provider&.id ]]).sort_by(&:first)
+        @matched_asks = (@matchable_asks + [[@match.receiver&.name_and_match_history.html_safe, @match.receiver&.id]]).sort_by(&:first)
+        @matched_offers = (@matchable_offers + [[@match.provider&.name_and_match_history.html_safe, @match.provider&.id]]).sort_by(&:first)
       else
 
       end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -7,13 +7,13 @@ class MatchesController < AdminController
     @matches = Match.status(params[:status] || 'all').order(updated_at: :desc)
 
     # follow_up_status filter
-    @statuses = Match::STATUSES.map{|s| [s.titleize, s]}
+    @statuses = Match::STATUSES.map {|s| [s.titleize, s]}
     if params[:follow_up_status].present?
       @matches = @matches.follow_up_status(params[:follow_up_status])
     end
 
     # connected_to_person_id filter
-    @people = Person.all.map{ |p| [p.name, p.id] }.sort_by(&:first)
+    @people = Person.all.map { |p| [p.name, p.id] }.sort_by(&:first)
     if params[:connected_to_person_id].present?
       person = Person.find(params[:connected_to_person_id])
       @matches = @matches.connected_to_person_id(person)
@@ -92,8 +92,8 @@ class MatchesController < AdminController
         @provider = Listing.where(type: type, id: params[:provider_id]).first
       end
 
-      @matchable_asks = Ask.matchable.map{ |a| [ a.name_and_match_history.html_safe, a.id ] }.sort_by(&:first)
-      @matchable_offers = Offer.matchable.map{ |o| [ o.name_and_match_history.html_safe, o.id] }.sort_by(&:first)
+      @matchable_asks = Ask.matchable.map { |a| [ a.name_and_match_history.html_safe, a.id ] }.sort_by(&:first)
+      @matchable_offers = Offer.matchable.map { |o| [ o.name_and_match_history.html_safe, o.id] }.sort_by(&:first)
 
       if @match.receiver_id && @match.provider_id
         @matched_asks = (@matchable_asks + [[@match.receiver&.name_and_match_history.html_safe, @match.receiver&.id ]]).sort_by(&:first)
@@ -101,7 +101,7 @@ class MatchesController < AdminController
       else
 
       end
-      @statuses = Match::STATUSES.map{|s| [s.titleize, s]}
+      @statuses = Match::STATUSES.map {|s| [s.titleize, s]}
 
       @communication_logs = CommunicationLog.where(match: @match)
 

--- a/app/controllers/service_areas_controller.rb
+++ b/app/controllers/service_areas_controller.rb
@@ -54,7 +54,7 @@ class ServiceAreasController < AdminController
 
     def set_form_dropdowns
       @service_area_location_type = LocationType.where(name: LocationType::SERVICE_AREA_TYPE).first_or_create!
-      @service_area_types = ServiceArea::TYPES.map { |i| [i,i] }
+      @service_area_types = ServiceArea::TYPES.map { |i| [i, i] }
     end
 
     def service_area_params

--- a/app/controllers/service_areas_controller.rb
+++ b/app/controllers/service_areas_controller.rb
@@ -54,7 +54,7 @@ class ServiceAreasController < AdminController
 
     def set_form_dropdowns
       @service_area_location_type = LocationType.where(name: LocationType::SERVICE_AREA_TYPE).first_or_create!
-      @service_area_types = ServiceArea::TYPES.map{ |i| [i,i] }
+      @service_area_types = ServiceArea::TYPES.map { |i| [i,i] }
     end
 
     def service_area_params

--- a/app/forms/listing_form.rb
+++ b/app/forms/listing_form.rb
@@ -15,7 +15,7 @@ class ListingForm < BaseForm
   def execute
     Listing.find_or_new(id).tap do |listing|
       listing.attributes = given_inputs
-        .reject{ |k, _v| k == :category }
+        .reject { |k, _v| k == :category }
         .merge(tag_list: category.lineage)
     end
   end

--- a/app/forms/location_form.rb
+++ b/app/forms/location_form.rb
@@ -25,6 +25,6 @@ class LocationForm < BaseForm
   private
 
     def given_inputs_without_location_type
-      given_inputs.reject {|key| key == :location_type }
+      given_inputs.reject { |key| key == :location_type }
     end
 end

--- a/app/forms/submission_form.rb
+++ b/app/forms/submission_form.rb
@@ -10,7 +10,7 @@ class SubmissionForm < BaseForm
     hash    :location_attributes,  strip: false
     hash    :person_attributes,    strip: false
     string  :form_name
-    string  :privacy_level_requested  # FIXME: not submitted as yet
+    string  :privacy_level_requested # FIXME: not submitted as yet
   end
 
   def execute

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,8 +10,8 @@ module ApplicationHelper
     "<span class='#{boolean ? "fa fa-check-circle has-text-success" : "fa fa-ban"}'></span>".html_safe
   end
 
-  def edit_button(resource, button_text='Edit', icon_class='fa fa-edit',
-                  button_text_class=nil, button_class=nil, params={}, button_title=nil, path=nil)
+  def edit_button(resource, button_text = 'Edit', icon_class = 'fa fa-edit',
+                  button_text_class = nil, button_class = nil, params = {}, button_title = nil, path = nil)
     if resource
       resource_class = resource.class
       if resource_class.superclass != ApplicationRecord
@@ -25,7 +25,7 @@ module ApplicationHelper
     end
   end
 
-  def show_button(resource, button_text='View', icon_class='fa fa-eye', margin_class=nil, button_text_class=nil, params={})
+  def show_button(resource, button_text = 'View', icon_class = 'fa fa-eye', margin_class = nil, button_text_class = nil, params = {})
     resource_class = resource.class
     if resource_class != Person && (resource_class.superclass != ApplicationRecord)
       resource = resource.becomes(resource.class.superclass)
@@ -37,7 +37,7 @@ module ApplicationHelper
     end
   end
 
-  def triage_button(resource, button_color_class=nil)
+  def triage_button(resource, button_color_class = nil)
     resource_class = resource.class
     if resource_class != Person && (resource_class.superclass != ApplicationRecord)
       resource = resource.becomes(resource.class.superclass)

--- a/app/helpers/communication_log_buttons.rb
+++ b/app/helpers/communication_log_buttons.rb
@@ -33,7 +33,7 @@ module CommunicationLogButtons
             title: 'New communication log',
             class: "button add-button #{margin_class} is-primary is-outlined",
             method: method,
-            remote: remote ) do
+            remote: remote) do
       "<span class='#{icon_class}'></span><span style='padding-left: 0.25em'> #{button_text}</span>".html_safe
     end
   end

--- a/app/helpers/index_action_buttons.rb
+++ b/app/helpers/index_action_buttons.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module IndexActionButtons
-  def clear_search_button(path=nil)
+  def clear_search_button(path = nil)
     if path
       link = path
     else

--- a/app/interactions/match_contribution.rb
+++ b/app/interactions/match_contribution.rb
@@ -13,9 +13,9 @@ class MatchContribution < ActiveInteraction::Base
 
   def match_receiver_and_provider
     if contribution.ask?
-      { receiver: contribution, provider: Offer.create!(counter_contribution_params) }
+      {receiver: contribution, provider: Offer.create!(counter_contribution_params)}
     elsif contribution.offer?
-      { receiver: Ask.create!(counter_contribution_params), provider: contribution }
+      {receiver: Ask.create!(counter_contribution_params), provider: contribution}
     else
       # TODO: check if community resource type when it's added
       raise "Unhandled contribution type: #{contribution.type}"
@@ -23,7 +23,7 @@ class MatchContribution < ActiveInteraction::Base
   end
 
   def counter_contribution_params
-    { person: person, service_area: contribution.service_area }
+    {person: person, service_area: contribution.service_area}
   end
 
   def person

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "#{Rails.root}/app/helpers/application_helper.rb"
-include ApplicationHelper  # TODO: better way to solve this?
+include ApplicationHelper # TODO: better way to solve this?
 
 # TODO: could do with specs
 class SubmissionMailer < ApplicationMailer

--- a/app/models/ask.rb
+++ b/app/models/ask.rb
@@ -3,8 +3,8 @@
 class Ask < Listing
   belongs_to :service_area, inverse_of: :asks
 
-  scope :matched, ->() { includes(:matches_as_receiver).references(:matches_as_receiver).where.not(matches: { provider_id: nil }) }
-  scope :unmatched, ->() { includes(:matches_as_receiver).references(:matches_as_receiver).where(matches: { provider_id: nil }) }
+  scope :matched, ->() { includes(:matches_as_receiver).references(:matches_as_receiver).where.not(matches: {provider_id: nil}) }
+  scope :unmatched, ->() { includes(:matches_as_receiver).references(:matches_as_receiver).where(matches: {provider_id: nil}) }
   scope :matchable, ->() { where(id: unmatched.pluck(:id) + inexhaustible.pluck(:id)) }
 end
 

--- a/app/models/browse_filter.rb
+++ b/app/models/browse_filter.rb
@@ -6,7 +6,7 @@
 class BrowseFilter
   FILTERS = {
     'ServiceArea' => ->(ids, scope) { scope.where(service_area: ids) },
-    'ContactMethod' => ->(ids, scope) { scope.joins(:person).where(people: { preferred_contact_method: ids })},
+    'ContactMethod' => ->(ids, scope) { scope.joins(:person).where(people: {preferred_contact_method: ids})},
     'Category' => lambda do |ids, scope|
       scope.tagged_with(
         Category.roots.where(id: ids).pluck('name'),

--- a/app/models/browse_filter.rb
+++ b/app/models/browse_filter.rb
@@ -6,7 +6,7 @@
 class BrowseFilter
   FILTERS = {
     'ServiceArea' => ->(ids, scope) { scope.where(service_area: ids) },
-    'ContactMethod' => ->(ids, scope) { scope.joins(:person).where(people: {preferred_contact_method: ids})},
+    'ContactMethod' => ->(ids, scope) { scope.joins(:person).where(people: {preferred_contact_method: ids}) },
     'Category' => lambda do |ids, scope|
       scope.tagged_with(
         Category.roots.where(id: ids).pluck('name'),
@@ -41,7 +41,7 @@ class BrowseFilter
 
   def filter(model)
     parameters.keys.reduce(model.matchable) do |scope, key|
-      filter = FILTERS.fetch(key, ->(_condition, s) {s})
+      filter = FILTERS.fetch(key, ->(_condition, s) { s })
       filter.call(parameters[key], scope)
     end
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -18,7 +18,7 @@ class Category < ApplicationRecord
   scope :roots,   -> { where(parent: nil).order(:display_order, :name) }
 
   # Currently only filtering by top-level categories
-  scope :as_filter_types, -> { roots.select(:id, :name)}
+  scope :as_filter_types, -> { roots.select(:id, :name) }
 
   def full_name
     "#{parent&.name&.upcase + ": " if parent}#{parent.present? ? name : name.upcase}"

--- a/app/models/communication_log.rb
+++ b/app/models/communication_log.rb
@@ -6,7 +6,7 @@ class CommunicationLog < ApplicationRecord
   belongs_to :match, optional: true
   belongs_to :created_by, optional: true, class_name: 'User', foreign_key: 'created_by_id'
 
-  scope :needs_follow_up, ->(boolean=nil) { where(needs_follow_up: boolean || true) }
+  scope :needs_follow_up, ->(boolean = nil) { where(needs_follow_up: boolean || true) }
 
   def self.log_email(email:, delivery_status:, person:, initiator: nil)
     create!(

--- a/app/models/communication_log.rb
+++ b/app/models/communication_log.rb
@@ -6,7 +6,7 @@ class CommunicationLog < ApplicationRecord
   belongs_to :match, optional: true
   belongs_to :created_by, optional: true, class_name: 'User', foreign_key: 'created_by_id'
 
-  scope :needs_follow_up, ->(boolean=nil){ where(needs_follow_up: boolean || true) }
+  scope :needs_follow_up, ->(boolean=nil) { where(needs_follow_up: boolean || true) }
 
   def self.log_email(email:, delivery_status:, person:, initiator: nil)
     create!(

--- a/app/models/contact_method.rb
+++ b/app/models/contact_method.rb
@@ -6,8 +6,8 @@ class ContactMethod < ApplicationRecord
   scope :as_filter_types, -> { enabled.distinct(:name) }
   scope :email, -> { find_by name: 'Email' }
   scope :enabled, -> { where enabled: true }
-  scope :field_name, -> (field_name){ where arel_table[:field].lower.eq(field_name) }
-  scope :method_name, -> (method_name){ where arel_table[:name].lower.eq(method_name) }
+  scope :field_name, -> (field_name) { where arel_table[:field].lower.eq(field_name) }
+  scope :method_name, -> (method_name) { where arel_table[:name].lower.eq(method_name) }
   scope :sample_one, -> { order(Arel.sql('RANDOM()')).first }
 
   def self.map_common_names_to_fields(name)

--- a/app/models/contact_method.rb
+++ b/app/models/contact_method.rb
@@ -6,8 +6,8 @@ class ContactMethod < ApplicationRecord
   scope :as_filter_types, -> { enabled.distinct(:name) }
   scope :email, -> { find_by name: 'Email' }
   scope :enabled, -> { where enabled: true }
-  scope :field_name, -> (field_name) { where arel_table[:field].lower.eq(field_name) }
-  scope :method_name, -> (method_name) { where arel_table[:name].lower.eq(method_name) }
+  scope :field_name, ->(field_name) { where arel_table[:field].lower.eq(field_name) }
+  scope :method_name, ->(method_name) { where arel_table[:name].lower.eq(method_name) }
   scope :sample_one, -> { order(Arel.sql('RANDOM()')).first }
 
   def self.map_common_names_to_fields(name)

--- a/app/models/contribution_type.rb
+++ b/app/models/contribution_type.rb
@@ -10,6 +10,6 @@ class ContributionType
 
   def self.where(id: [], name: [])
     ids = (id + name).flatten
-    ids.map {|i| TYPES.find {|t| t.id == i }}
+    ids.map { |i| TYPES.find { |t| t.id == i } }
   end
 end

--- a/app/models/custom_form_question.rb
+++ b/app/models/custom_form_question.rb
@@ -35,7 +35,7 @@ class CustomFormQuestion < ApplicationRecord
       .where("mobility_string_translations.key = 'name' AND mobility_string_translations.locale = 'en'")
       .where('mobility_string_translations.value ILIKE ?', "%#{stem}%") }
 
-  scope :for_form, ->(form) { joins(:form_questions).where(form_questions: { form: form }) }
+  scope :for_form, ->(form) { joins(:form_questions).where(form_questions: {form: form}) }
 
   scope :ordered, ->() { order(:display_order) }
 end

--- a/app/models/history_log.rb
+++ b/app/models/history_log.rb
@@ -13,7 +13,7 @@ class HistoryLog < ApplicationRecord
   #                topic: "#{klass.name} #{log_type}")
   # end
 
-  def self.generate_import_log!(current_user, import_klass, extra_detail=nil)
+  def self.generate_import_log!(current_user, import_klass, extra_detail = nil)
     self.create!(name: extra_detail + ' +++ ' + "IMPORTED BY: #{current_user&.name}",
                  topic: "#{import_klass.name} IMPORTED")
   end

--- a/app/models/importers/base_importer.rb
+++ b/app/models/importers/base_importer.rb
@@ -66,7 +66,7 @@ class Importers::BaseImporter
     results = []
     required_fields_array.map do |rr|
       if rr.class == Array
-        if rr.map {|r| row[r]}.any?
+        if rr.map { |r| row[r] }.any?
           results << true
         else
           rr.map do |r|

--- a/app/models/importers/base_importer.rb
+++ b/app/models/importers/base_importer.rb
@@ -32,11 +32,11 @@ class Importers::BaseImporter
     @new_records_count = 0
     @dupe_records_count = 0
     @row_processing_error_messages = []
-    @counts_hash = { row_count: @row_count,
+    @counts_hash = {row_count: @row_count,
                     row_success_count: @row_success_count,
                     new_records_count: @new_records_count,
                     dupe_records_count: @dupe_records_count,
-                    row_error_count: @row_error_count }
+                    row_error_count: @row_error_count}
     @initial_model_logs = ''
     @initial_model_counts = {}
     @final_diff_model_counts = {}

--- a/app/models/importers/base_importer.rb
+++ b/app/models/importers/base_importer.rb
@@ -223,7 +223,7 @@ class Importers::BaseImporter
     @final_diff_model_counts = final_counts_hash
   end
 
-  def create_history_log(row, error_message=nil)
+  def create_history_log(row, error_message = nil)
     begin
       extra_detail = '+++ row_number#: ' +
           @row_number.to_s +

--- a/app/models/importers/base_importer.rb
+++ b/app/models/importers/base_importer.rb
@@ -66,7 +66,7 @@ class Importers::BaseImporter
     results = []
     required_fields_array.map do |rr|
       if rr.class == Array
-        if rr.map{|r| row[r]}.any?
+        if rr.map {|r| row[r]}.any?
           results << true
         else
           rr.map do |r|

--- a/app/models/importers/base_importer.rb
+++ b/app/models/importers/base_importer.rb
@@ -276,14 +276,14 @@ def parse_date(date_string)
       date = Date.new(y.to_i, m.to_i, d.to_i)
     else
       begin
-        date = date_string.to_date  # TODO: - add exception?
+        date = date_string.to_date # TODO: - add exception?
       rescue => e
         binding.pry ### USE FOR TESTING IMPORTERS
       end
     end
   elsif date_string&.include?('-')
     begin
-      date = date_string.to_date  # TODO: - add exception?
+      date = date_string.to_date # TODO: - add exception?
     rescue => e
       binding.pry ### USE FOR TESTING IMPORTERS
     end

--- a/app/models/importers/submission_response_importer.rb
+++ b/app/models/importers/submission_response_importer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Importers::SubmissionResponseImporter < Importers::BaseImporter
-  def initialize(current_user, form_type, categories_question_name=nil)
+  def initialize(current_user, form_type, categories_question_name = nil)
     require "#{Rails.root}/db/scripts/tuple_counts.rb"
     # audit_info(current_user) # TODO
     set_klasses

--- a/app/models/importers/user_importer.rb
+++ b/app/models/importers/user_importer.rb
@@ -12,7 +12,7 @@ class Importers::UserImporter < Importers::BaseImporter
   end
 
   def klasses_array
-    [Person,User]
+    [Person, User]
   end
 
   def required_fields_array

--- a/app/models/importers/user_importer.rb
+++ b/app/models/importers/user_importer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Importers::UserImporter < Importers::BaseImporter
-  def initialize(current_user, create_users_if_possible=true)
+  def initialize(current_user, create_users_if_possible = true)
     require "#{Rails.root}/db/scripts/tuple_counts.rb"
     audit_info(current_user)
     set_klasses

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -25,14 +25,14 @@ class Listing < ApplicationRecord
 
   MATCH_STATUSES = ['matched', 'unmatched']
 
-  scope :asks, ->(){ where(type: Ask.to_s) }
-  scope :offers, ->(){ where(type: Offer.to_s) }
-  scope :created_on, ->(created_on){ where('created_at::date = ?', created_on) }
+  scope :asks, ->() { where(type: Ask.to_s) }
+  scope :offers, ->() { where(type: Offer.to_s) }
+  scope :created_on, ->(created_on) { where('created_at::date = ?', created_on) }
   scope :inexhaustible, ->() { where(inexhaustible: true) }
-  scope :location_id, ->(location_id){ where(location_id: location_id.to_i) }
-  scope :match_status, ->(match_status){ where(state: match_status.to_s) }
-  scope :person_id, ->(person_id){ where(person_id: person_id.to_i) }
-  scope :service_area_name, ->(service_area_name){ includes(service_area: :mobility_string_translations)
+  scope :location_id, ->(location_id) { where(location_id: location_id.to_i) }
+  scope :match_status, ->(match_status) { where(state: match_status.to_s) }
+  scope :person_id, ->(person_id) { where(person_id: person_id.to_i) }
+  scope :service_area_name, ->(service_area_name) { includes(service_area: :mobility_string_translations)
       .references(:mobility_string_translations)
       .where('mobility_string_translations.value = ?', service_area_name.to_s)
   }
@@ -63,9 +63,9 @@ class Listing < ApplicationRecord
   def status
     status = 'unmatched'
     if matches_as_receiver.any?
-      status = matches_as_receiver.map{|m| m.completed?}.any? ? 'completed' : 'matched'
+      status = matches_as_receiver.map {|m| m.completed?}.any? ? 'completed' : 'matched'
     elsif matches_as_provider.any?
-      status = matches_as_provider.map{|m| m.completed?}.any? ? 'completed' : 'matched'
+      status = matches_as_provider.map {|m| m.completed?}.any? ? 'completed' : 'matched'
     end
     update(state: status)
     status

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -21,7 +21,7 @@ class Listing < ApplicationRecord
 
   validates :type, presence: true
 
-  enum state: { unmatched: 0, matched: 1 }
+  enum state: {unmatched: 0, matched: 1}
 
   MATCH_STATUSES = ['matched', 'unmatched']
 

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -63,9 +63,9 @@ class Listing < ApplicationRecord
   def status
     status = 'unmatched'
     if matches_as_receiver.any?
-      status = matches_as_receiver.map {|m| m.completed?}.any? ? 'completed' : 'matched'
+      status = matches_as_receiver.map { |m| m.completed? }.any? ? 'completed' : 'matched'
     elsif matches_as_provider.any?
-      status = matches_as_provider.map {|m| m.completed?}.any? ? 'completed' : 'matched'
+      status = matches_as_provider.map { |m| m.completed? }.any? ? 'completed' : 'matched'
     end
     update(state: status)
     status

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -13,11 +13,13 @@ class Location < ApplicationRecord
   scope :city, ->(city) { where(city: city.to_s) }
   scope :location_type_name, ->(location_type_name) { joins(:location_type).where('location_types.name = ?', location_type_name.to_s) }
   scope :person_id, ->(person_id) { where(person_id: person_id.to_i) }
-  scope :service_area_name, ->(service_area_name) { includes(listings: { service_area: :mobility_string_translations })
-      .references(listings: { service_area: :mobility_string_translations })
+  scope :street_address, ->(street_address) { where(street_address: street_address.to_s) }
+
+  scope :service_area_name, ->(service_area_name) {
+    includes(listings: {service_area: :mobility_string_translations})
+      .references(listings: {service_area: :mobility_string_translations})
       .where('mobility_string_translations.value = ?', service_area_name.to_s)
   }
-  scope :street_address, ->(street_address) { where(street_address: street_address.to_s) }
 
   def name
     "#{address}#{" (" + location_type&.name + ")" if location_type}"

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -10,14 +10,14 @@ class Location < ApplicationRecord
   has_many :people
   has_many :service_areas
 
-  scope :city, ->(city){ where(city: city.to_s) }
-  scope :location_type_name, ->(location_type_name){ joins(:location_type).where('location_types.name = ?', location_type_name.to_s) }
-  scope :person_id, ->(person_id){ where(person_id: person_id.to_i) }
-  scope :service_area_name, ->(service_area_name){ includes(listings: { service_area: :mobility_string_translations })
+  scope :city, ->(city) { where(city: city.to_s) }
+  scope :location_type_name, ->(location_type_name) { joins(:location_type).where('location_types.name = ?', location_type_name.to_s) }
+  scope :person_id, ->(person_id) { where(person_id: person_id.to_i) }
+  scope :service_area_name, ->(service_area_name) { includes(listings: { service_area: :mobility_string_translations })
       .references(listings: { service_area: :mobility_string_translations })
       .where('mobility_string_translations.value = ?', service_area_name.to_s)
   }
-  scope :street_address, ->(street_address){ where(street_address: street_address.to_s) }
+  scope :street_address, ->(street_address) { where(street_address: street_address.to_s) }
 
   def name
     "#{address}#{" (" + location_type&.name + ")" if location_type}"

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -17,7 +17,7 @@ class Match < ApplicationRecord
   #
 
   scope :id, ->(id) { where(id: id) }
-  scope :match_ids, -> (match_ids) { where('matches.id::text = ANY (ARRAY[?])', match_ids) }
+  scope :match_ids, ->(match_ids) { where('matches.id::text = ANY (ARRAY[?])', match_ids) }
   scope :needs_follow_up, ->() { joins(:communication_logs).where('communication_logs.needs_follow_up = ?', true) }
   scope :status, ->(status) { where(status == 'all' || !status.present? ? 'matches.id IS NOT NULL' : "matches.status = '#{status.downcase}'") }
   scope :this_month, -> { where('matches.created_at >= ? AND matches.created_at <= ?',

--- a/app/models/mobility_string_translation.rb
+++ b/app/models/mobility_string_translation.rb
@@ -9,7 +9,7 @@ class MobilityStringTranslation < ApplicationRecord
   validates :key, presence: true
   validates :value, presence: true
 
-  validates :translatable_id, uniqueness: { scope: %i[translatable_type locale key] }
+  validates :translatable_id, uniqueness: {scope: %i[translatable_type locale key]}
 
   scope :translatable, ->(record) { where(translatable_id: record.id).where(translatable_type: record.class.to_s) }
   scope :locale, ->(locale) { where('locale ILIKE ?', locale) }

--- a/app/models/mobility_text_translation.rb
+++ b/app/models/mobility_text_translation.rb
@@ -9,7 +9,7 @@ class MobilityTextTranslation < ApplicationRecord
   validates :key, presence: true
   validates :value, presence: true
 
-  validates :translatable_id, uniqueness: { scope: %i[translatable_type locale key] }
+  validates :translatable_id, uniqueness: {scope: %i[translatable_type locale key]}
 
   scope :translatable, ->(record) { where(translatable_id: record.id).where(translatable_type: record.class.to_s) }
   scope :locale, ->(locale) { where('locale ILIKE ?', locale) }

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -3,8 +3,8 @@
 class Offer < Listing
   belongs_to :service_area, inverse_of: :offers
 
-  scope :matched, ->() { includes(:matches_as_provider).references(:matches_as_provider).where.not(matches: { receiver_id: nil }) }
-  scope :unmatched, ->() { includes(:matches_as_provider).references(:matches_as_provider).where(matches: { receiver_id: nil }) }
+  scope :matched, ->() { includes(:matches_as_provider).references(:matches_as_provider).where.not(matches: {receiver_id: nil}) }
+  scope :unmatched, ->() { includes(:matches_as_provider).references(:matches_as_provider).where(matches: {receiver_id: nil}) }
   scope :matchable, ->() { where(id: unmatched.pluck(:id) + inexhaustible.pluck(:id)) }
 end
 

--- a/app/models/service_area.rb
+++ b/app/models/service_area.rb
@@ -25,7 +25,7 @@ class ServiceArea < ApplicationRecord
 
   accepts_nested_attributes_for :location
 
-  scope :order_by_translated_name, ->(locale=:en) {
+  scope :order_by_translated_name, ->(locale = :en) {
     includes(:mobility_string_translations).references(:mobility_string_translations)
     .where('mobility_string_translations.locale = ?', locale.to_s)
     .where('mobility_string_translations.key = ?', 'name')

--- a/app/models/service_area.rb
+++ b/app/models/service_area.rb
@@ -25,7 +25,7 @@ class ServiceArea < ApplicationRecord
 
   accepts_nested_attributes_for :location
 
-  scope :order_by_translated_name, -> (locale=:en){
+  scope :order_by_translated_name, -> (locale=:en) {
     includes(:mobility_string_translations).references(:mobility_string_translations)
     .where('mobility_string_translations.locale = ?', locale.to_s)
     .where('mobility_string_translations.key = ?', 'name')

--- a/app/models/service_area.rb
+++ b/app/models/service_area.rb
@@ -25,7 +25,7 @@ class ServiceArea < ApplicationRecord
 
   accepts_nested_attributes_for :location
 
-  scope :order_by_translated_name, -> (locale=:en) {
+  scope :order_by_translated_name, ->(locale=:en) {
     includes(:mobility_string_translations).references(:mobility_string_translations)
     .where('mobility_string_translations.locale = ?', locale.to_s)
     .where('mobility_string_translations.key = ?', 'name')

--- a/app/models/software_feedback.rb
+++ b/app/models/software_feedback.rb
@@ -5,16 +5,19 @@ class SoftwareFeedback < ApplicationRecord
 
   FEEDBACK_TYPES = ['new feature', 'change', 'bug']
   MODULE_NAMES = [
-    'ask form', 'offer form', 'contributions page' ] + [
-      'admin',
-      'system settings',
-      'community resources module',
-      'announcements module',
-      'donations module',
-      'positions module',
-      'shared accounts module',
-      'yearbook'
-    ].sort
+    'ask form',
+    'offer form',
+    'contributions page'
+  ] + [
+    'admin',
+    'system settings',
+    'community resources module',
+    'announcements module',
+    'donations module',
+    'positions module',
+    'shared accounts module',
+    'yearbook'
+  ].sort
   URGENCIES = ['critical', 'anytime', 'blue sky']
 end
 

--- a/app/models/system_setting.rb
+++ b/app/models/system_setting.rb
@@ -5,9 +5,9 @@ class SystemSetting < ApplicationRecord
 
   EXCHANGE_TYPES = [
       'fully_moderated', # no public access
-      'dispatch_moderated',  # peer-to-peer, but
+      'dispatch_moderated', # peer-to-peer, but
       'moderation_on_request', # option on Forms to request hidden from public and/or messaging moderation
-      'dispatch_assisted',  # peer-to-peer, but admins (dispatch/connectors/coordinators) can also complete matches
+      'dispatch_assisted', # peer-to-peer, but admins (dispatch/connectors/coordinators) can also complete matches
       'peer_to_peer' # everything is public
   ]
 

--- a/app/models/urgency_level.rb
+++ b/app/models/urgency_level.rb
@@ -18,6 +18,6 @@ class UrgencyLevel
 
   def self.where(id: [])
     ids = [id].flatten
-    ids.map {|i| TYPES.select {|t| t.id == i }}
+    ids.map { |i| TYPES.select { |t| t.id == i } }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :confirmable, :lockable, :timeoutable, :trackable# and :omniauthable
+         :confirmable, :lockable, :timeoutable, :trackable # and :omniauthable
 
   has_many :communication_logs, as: :created_by
   has_one :person

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,7 +80,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Set default mailer url
-  config.action_mailer.default_url_options = { host: ENV['SYSTEM_HOST_NAME'] }
+  config.action_mailer.default_url_options = {host: ENV['SYSTEM_HOST_NAME']}
 
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
   config.action_mailer.perform_caching = false
   # Required here for CircleCI; FIXME: set via env vars instead
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = {host: 'localhost', port: 3000}
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -56,14 +56,14 @@ SimpleForm.setup do |config|
     ## Inputs
     # b.use :input, class: 'input', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :label_input
-    b.use :hint,  wrap_with: { tag: :span, class: 'help has-text-grey-light' }
-    b.use :error, wrap_with: { tag: :span, class: :error }
+    b.use :hint,  wrap_with: {tag: :span, class: 'help has-text-grey-light'}
+    b.use :error, wrap_with: {tag: :span, class: :error}
 
     ## full_messages_for
     # If you want to display the full error message for the attribute, you can
     # use the component :full_error, like:
     #
-    b.use :full_error, wrap_with: { tag: :span, class: :error }
+    b.use :full_error, wrap_with: {tag: :span, class: :error}
   end
 
   # The default wrapper to be used by the FormBuilder.

--- a/config/initializers/simple_form_bulma.rb
+++ b/config/initializers/simple_form_bulma.rb
@@ -66,10 +66,10 @@ SimpleForm.setup do |config|
     # b.use :hint, wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
     # b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
     b.wrapper tag: 'div', class: 'field' do |ba|
-      ba.use :label, class: 'label', wrap_with: { tag: 'label', class: 'label' }
+      ba.use :label, class: 'label', wrap_with: {tag: 'label', class: 'label'}
       ba.use :input, class: 'input'
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'help invalid-feedback is-danger' }
-      ba.use :hint,  wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
+      ba.use :full_error, wrap_with: {tag: 'div', class: 'help invalid-feedback is-danger'}
+      ba.use :hint,  wrap_with: {tag: 'p', class: 'help has-text-grey-light'}
     end
   end
 
@@ -79,8 +79,8 @@ SimpleForm.setup do |config|
     b.use :placeholder
     b.optional :pattern
     b.optional :readonly
-    b.use :input, wrap_with: { tag: 'div', class: 'select' }
-    b.use :full_error, wrap_with: { tag: 'div', class: 'help invalid-feedback is-danger' }
+    b.use :input, wrap_with: {tag: 'div', class: 'select'}
+    b.use :full_error, wrap_with: {tag: 'div', class: 'help invalid-feedback is-danger'}
     # b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
   end
 
@@ -94,9 +94,9 @@ SimpleForm.setup do |config|
     b.wrapper tag: 'div', class: 'control' do |ba|
       ba.use :input, class: 'input'
     end
-    b.use :input, class: 'file-input', wrap_with: { tag: 'label', class: 'file-label' }
-    b.use :full_error, wrap_with: { tag: 'div', class: 'help invalid-feedback is-danger' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :input, class: 'file-input', wrap_with: {tag: 'label', class: 'file-label'}
+    b.use :full_error, wrap_with: {tag: 'div', class: 'help invalid-feedback is-danger'}
+    b.use :hint, wrap_with: {tag: 'small', class: 'form-text text-muted'}
   end
 
   # bulma extension vertical input for boolean
@@ -106,10 +106,10 @@ SimpleForm.setup do |config|
     b.use :input, class: 'is-checkradio is-info'
     b.use :label
     b.wrapper :form_check_wrapper, tag: 'div', class: 'control' do |bb|
-      bb.use :input, wrap_with: { tag: 'label', class: 'checkbox' }
+      bb.use :input, wrap_with: {tag: 'label', class: 'checkbox'}
       bb.use :label, class: 'checkbox'
-      bb.use :full_error, wrap_with: { tag: 'div', class: 'help invalid-feedback is-danger' }
-      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      bb.use :full_error, wrap_with: {tag: 'div', class: 'help invalid-feedback is-danger'}
+      bb.use :hint, wrap_with: {tag: 'small', class: 'form-text text-muted'}
     end
     # b.wrapper tag: 'div', class: 'checkbox' do |ba|
       #     ba.use :label_input
@@ -128,8 +128,8 @@ SimpleForm.setup do |config|
     b.optional :step
     b.use :label
     b.use :input, class: 'form-control-range', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'help invalid-feedback is-danger' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :full_error, wrap_with: {tag: 'div', class: 'help invalid-feedback is-danger'}
+    b.use :hint, wrap_with: {tag: 'small', class: 'form-text text-muted'}
   end
 
   config.wrappers :vertical_radio, tag: 'div', class: 'vertical-radio', error_class: 'has-error' do |b|
@@ -143,8 +143,8 @@ SimpleForm.setup do |config|
        end
      end
     end
-    b.use :full_error, wrap_with: { tag: 'span', class: 'help invalid-feedback is-danger' }
-    b.use :hint, wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
+    b.use :full_error, wrap_with: {tag: 'span', class: 'help invalid-feedback is-danger'}
+    b.use :hint, wrap_with: {tag: 'p', class: 'help has-text-grey-light'}
   end
 
   config.wrappers :vertical_checkboxes, tag: 'div', class: 'vertical-checkboxes', error_class: 'has-error' do |b|
@@ -158,8 +158,8 @@ SimpleForm.setup do |config|
         end
       end
     end
-    b.use :full_error, wrap_with: { tag: 'span', class: 'help invalid-feedback is-danger' }
-    b.use :hint, wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
+    b.use :full_error, wrap_with: {tag: 'span', class: 'help invalid-feedback is-danger'}
+    b.use :hint, wrap_with: {tag: 'p', class: 'help has-text-grey-light'}
   end
 
     ## vertical input for radio buttons and check boxes
@@ -202,8 +202,8 @@ SimpleForm.setup do |config|
       b.wrapper :input, tag: 'div', class: 'field-body' do |bi|
         bi.wrapper :input, tag: 'div', class: 'field' do |bf|
           bf.use :input, class: 'input'
-          bf.use :full_error, wrap_with: { tag: 'span', class: 'help invalid-feedback is-danger' }
-          bf.optional :hint, wrap_with: { tag: 'p', class: 'help' }
+          bf.use :full_error, wrap_with: {tag: 'span', class: 'help invalid-feedback is-danger'}
+          bf.optional :hint, wrap_with: {tag: 'p', class: 'help'}
         end
       end
     end
@@ -230,10 +230,10 @@ SimpleForm.setup do |config|
       b.optional :min_max
       b.optional :readonly
       b.wrapper :grid_wrapper, tag: 'div', class: 'field' do |ba|
-        ba.use :label, class: 'label', wrap_with: { tag: 'label', class: 'label' }
+        ba.use :label, class: 'label', wrap_with: {tag: 'label', class: 'label'}
         ba.use :input, class: 'input', error_class: 'is-invalid', valid_class: 'is-valid'
-        ba.use :full_error, wrap_with: { tag: 'div', class: 'help invalid-feedback is-danger' }
-        ba.use :hint, wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
+        ba.use :full_error, wrap_with: {tag: 'div', class: 'help invalid-feedback is-danger'}
+        ba.use :hint, wrap_with: {tag: 'p', class: 'help has-text-grey-light'}
       end
     end
 
@@ -262,10 +262,10 @@ SimpleForm.setup do |config|
       b.use :label
       b.wrapper tag: 'div', class: 'field-body' do |ba|
         ba.wrapper :form_check_wrapper, tag: 'div', class: 'control field is-horizontal' do |bb|
-          bb.use :input, wrap_with: { tag: 'label field-label field-label-left', class: 'checkbox' }
+          bb.use :input, wrap_with: {tag: 'label field-label field-label-left', class: 'checkbox'}
           bb.use :label, class: 'checkbox'
-          bb.use :full_error, wrap_with: { tag: 'div', class: 'help invalid-feedback is-danger' }
-          bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+          bb.use :full_error, wrap_with: {tag: 'div', class: 'help invalid-feedback is-danger'}
+          bb.use :hint, wrap_with: {tag: 'small', class: 'form-text text-muted'}
         end
       end
       # b.wrapper tag: 'div', class: 'checkbox' do |ba|
@@ -287,8 +287,8 @@ SimpleForm.setup do |config|
            baaa.use :input, class: 'radio', type: 'radio'
          end
        end
-       ba.use :full_error, wrap_with: { tag: 'span', class: 'help invalid-feedback is-danger' }
-       ba.use :hint, wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
+       ba.use :full_error, wrap_with: {tag: 'span', class: 'help invalid-feedback is-danger'}
+       ba.use :hint, wrap_with: {tag: 'p', class: 'help has-text-grey-light'}
       end
     end
 
@@ -303,8 +303,8 @@ SimpleForm.setup do |config|
           end
         end
       end
-      b.use :full_error, wrap_with: { tag: 'span', class: 'help invalid-feedback is-danger' }
-      b.use :hint, wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
+      b.use :full_error, wrap_with: {tag: 'span', class: 'help invalid-feedback is-danger'}
+      b.use :hint, wrap_with: {tag: 'p', class: 'help has-text-grey-light'}
     end
 
     ## horizontal input for radio buttons and check boxes
@@ -360,8 +360,8 @@ SimpleForm.setup do |config|
     #     ba.use :error, wrap_with: { tag: 'span', class: 'help has-text-grey-light' }
     #     ba.use :hint,  wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
     # end
-    b.use :full_error, wrap_with: { tag: 'div', class: 'help invalid-feedback is-danger' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'help' }
+    b.use :full_error, wrap_with: {tag: 'div', class: 'help invalid-feedback is-danger'}
+    b.use :hint, wrap_with: {tag: 'small', class: 'help'}
   end
 
     ## horizontal multi select
@@ -372,9 +372,9 @@ SimpleForm.setup do |config|
       b.wrapper :grid_wrapper, tag: 'div', class: 'control' do |ba|
         ba.wrapper tag: 'div', class: 'field is-grouped' do |bb|
           bb.use :input, class: 'input', error_class: 'is-invalid', valid_class: 'is-valid'
-          ba.use :hint, wrap_with: { tag: 'small', class: 'help' } # adds hint above select
+          ba.use :hint, wrap_with: {tag: 'small', class: 'help'} # adds hint above select
         end
-        ba.use :full_error, wrap_with: { tag: 'div', class: 'help is-invalid invalid-feedback is-danger' }
+        ba.use :full_error, wrap_with: {tag: 'div', class: 'help is-invalid invalid-feedback is-danger'}
       end
     end
 

--- a/config/initializers/simple_form_bulma.rb
+++ b/config/initializers/simple_form_bulma.rb
@@ -144,7 +144,7 @@ SimpleForm.setup do |config|
      end
     end
     b.use :full_error, wrap_with: { tag: 'span', class: 'help invalid-feedback is-danger' }
-    b.use :hint,  wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
+    b.use :hint, wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
   end
 
   config.wrappers :vertical_checkboxes, tag: 'div', class: 'vertical-checkboxes', error_class: 'has-error' do |b|
@@ -159,7 +159,7 @@ SimpleForm.setup do |config|
       end
     end
     b.use :full_error, wrap_with: { tag: 'span', class: 'help invalid-feedback is-danger' }
-    b.use :hint,  wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
+    b.use :hint, wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
   end
 
     ## vertical input for radio buttons and check boxes
@@ -288,7 +288,7 @@ SimpleForm.setup do |config|
          end
        end
        ba.use :full_error, wrap_with: { tag: 'span', class: 'help invalid-feedback is-danger' }
-       ba.use :hint,  wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
+       ba.use :hint, wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
       end
     end
 
@@ -304,7 +304,7 @@ SimpleForm.setup do |config|
         end
       end
       b.use :full_error, wrap_with: { tag: 'span', class: 'help invalid-feedback is-danger' }
-      b.use :hint,  wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
+      b.use :hint, wrap_with: { tag: 'p', class: 'help has-text-grey-light' }
     end
 
     ## horizontal input for radio buttons and check boxes

--- a/db/migrate/20200510043912_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200510043912_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -12,7 +12,7 @@ ActsAsTaggableOnMigration.class_eval do
     end
 
     create_table ActsAsTaggableOn.taggings_table do |t|
-      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+      t.references :tag, foreign_key: {to_table: ActsAsTaggableOn.tags_table}
 
       # You should make sure that the column created is
       # long enough to store the required class names.

--- a/db/migrate/20201121210338_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20201121210338_create_active_storage_tables.active_storage.rb
@@ -10,7 +10,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.string   :checksum,   null: false
       t.datetime :created_at, null: false
 
-      t.index [ :key ], unique: true
+      t.index [:key], unique: true
     end
 
     create_table :active_storage_attachments do |t|
@@ -20,7 +20,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
 
       t.datetime :created_at, null: false
 
-      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.index [:record_type, :record_id, :name, :blob_id], name: "index_active_storage_attachments_uniqueness", unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end

--- a/db/migrate/20201121210339_create_action_text_tables.action_text.rb
+++ b/db/migrate/20201121210339_create_action_text_tables.action_text.rb
@@ -8,7 +8,7 @@ class CreateActionTextTables < ActiveRecord::Migration[6.0]
 
       t.timestamps
 
-      t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
+      t.index [:record_type, :record_id, :name], name: "index_action_text_rich_texts_uniqueness", unique: true
     end
   end
 end

--- a/db/scripts/truncate_tables.rb
+++ b/db/scripts/truncate_tables.rb
@@ -15,7 +15,7 @@ def truncate_table(table_name, connection)
 end
 
 ActiveRecord::Base.connection.tables.each do |table_name|
-  unless  ["ar_internal_metadata", "schema_migrations"].include?(table_name)
+  unless ["ar_internal_metadata", "schema_migrations"].include?(table_name)
     truncate_table(table_name, connection)
   end
 end

--- a/db/scripts/tuple_counts.rb
+++ b/db/scripts/tuple_counts.rb
@@ -33,7 +33,7 @@ def check_table_count(table_name, connection, class_name)
     max_id = result
   end
 
-  puts "#{ count.to_s.rjust(3, " ") } / #{max_id.to_s.ljust(3, "_")}" +
+  puts "#{count.to_s.rjust(3, " ")} / #{max_id.to_s.ljust(3, "_")}" +
            "___" + class_name.to_s
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -72,7 +72,8 @@ locales.each do |locale, locale_name|
   SystemLocale.where(locale: locale).first_or_create!(locale_name: locale_name)
 end
 
-[ ['Call', 'phone', 'fa fa-phone'],
+[
+  ['Call', 'phone', 'fa fa-phone'],
   ['Text', 'phone', 'fa fa-comment'],
   ['Email', 'email', 'fa fa-envelope'],
   ['WhatsApp', 'phone', 'fa fa-whatsapp'],

--- a/db/seeds/dev_seeds.rb
+++ b/db/seeds/dev_seeds.rb
@@ -81,7 +81,7 @@ end
 
 match_1 = Match.where(receiver: person.asks.last, provider: person_2.offers.last).first_or_create!
 5.times do
-  Match.where(receiver: Ask.all.sample, provider: Offer.all.sample).first_or_create!(created_at: Time.current - ( ((1..10).to_a.sample).days))
+  Match.where(receiver: Ask.all.sample, provider: Offer.all.sample).first_or_create!(created_at: Time.current - (((1..10).to_a.sample).days))
 end
 
 # organization
@@ -95,7 +95,7 @@ CommunityResource.where(
 5.times do
   org = Organization.create!(name: Faker::Company.name)
   CommunityResource.create!(name: Faker::Lorem.words(number: (2..5).to_a.sample).join(" "),
-                            is_approved: [true,false].sample,
+                            is_approved: [true, false].sample,
                             publish_from: Faker::Time.between(from: Time.now - 20.days, to: DateTime.now),
                             description: Faker::Lorem.sentences(number: (1..5).to_a.sample).join(" "), organization: org)
 end
@@ -107,7 +107,7 @@ Announcement.where(
 ).first_or_create!(publish_from: Faker::Time.between(from: Time.now - 20.days, to: DateTime.now))
 5.times do
   Announcement.create!(name: Faker::Lorem.words(number: (2..5).to_a.sample).join(" "),
-                       is_approved: [true,false].sample,
+                       is_approved: [true, false].sample,
                        publish_from: Faker::Time.between(from: Time.now - 20.days, to: DateTime.now),
                        description: Faker::Lorem.sentences(number: (1..6).to_a.sample).join(" "))
 end
@@ -158,7 +158,7 @@ end
                          urgency: SoftwareFeedback::URGENCIES.sample).first_or_create!
 end
 
-Match.all.sample((Match.count * 50)/100).each do |match|
+Match.all.sample((Match.count * 50) / 100).each do |match|
   Feedback.create!(match: match,
                    is_from_receiver: [true, false].sample,
                    completed: [true, false].sample,
@@ -199,7 +199,7 @@ Listing.all.each do |listing|
                           )
 end
 # 70% get random manual logs
-Listing.all.sample((Listing.count * 70)/100) do |listing|
+Listing.all.sample((Listing.count * 70) / 100) do |listing|
   delivery_status = (Messenger.delivery_statuses - Messenger.default_status).sample
   CommunicationLog.create!(person: listing.person,
                            match: listing.matches.first,

--- a/lib/tasks/one_time.rake
+++ b/lib/tasks/one_time.rake
@@ -15,7 +15,7 @@ namespace :one_time do
       new_listings = converter.convert listing
 
       puts "-, #{listing.id}, #{listing.reload.tag_list}"
-      new_listings.each{ |new_listing| puts "+, #{new_listing.id}, #{new_listing.tag_list}" }
+      new_listings.each { |new_listing| puts "+, #{new_listing.id}, #{new_listing.tag_list}" }
     end
   end
 

--- a/lib/tasks/support/listing_converter.rb
+++ b/lib/tasks/support/listing_converter.rb
@@ -30,13 +30,13 @@ class ListingConverter
     end
 
     def gather_lineages
-      Category.all.map{ |category| [category.name, category.lineage] }.to_h
+      Category.all.map { |category| [category.name, category.lineage] }.to_h
     end
 
     def split tag_list
       matching_lineages = lineages
         .values_at(*tag_list)
-        .sort_by{ |lineage| lineage.size }
+        .sort_by { |lineage| lineage.size }
         .reverse
 
       matching_lineages.reduce([]) do |minimal_set, lineage|

--- a/spec/blueprints/contribution_blueprint_spec.rb
+++ b/spec/blueprints/contribution_blueprint_spec.rb
@@ -47,13 +47,13 @@ RSpec.describe ContributionBlueprint do
 
   it 'allows injecting a url formatter for the view_path' do
     expected_path = "/testing_#{contribution.id}"
-    result = ContributionBlueprint.render(contribution, view_path: ->(p_id) { "/testing_#{p_id}"})
+    result = ContributionBlueprint.render(contribution, view_path: ->(p_id) { "/testing_#{p_id}" })
     expect(JSON.parse(result)['view_path']).to eq(expected_path)
   end
 
   it 'allows injecting a url formatter for the profile_path' do
     expected_path = "/testing_#{contribution.person.id}"
-    result = ContributionBlueprint.render(contribution, profile_path: ->(p_id) { "/testing_#{p_id}"})
+    result = ContributionBlueprint.render(contribution, profile_path: ->(p_id) { "/testing_#{p_id}" })
     expect(JSON.parse(result)['profile_path']).to eq(expected_path)
   end
 end

--- a/spec/blueprints/contribution_blueprint_spec.rb
+++ b/spec/blueprints/contribution_blueprint_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe ContributionBlueprint do
     expected_area_name = Faker::Address.community
     contribution.service_area.name = expected_area_name
     contribution.service_area.save!
-    expected_data = { 'contributions' =>
+    expected_data = {'contributions' =>
                           [{
                                'id' => contribution.id,
                                'contribution_type' => 'Ask',
-                               'category_tags' => [{ 'id' => expected_category_id, 'name' => expected_category }],
+                               'category_tags' => [{'id' => expected_category_id, 'name' => expected_category}],
                                'inexhaustible' => contribution.inexhaustible,
-                               'urgency' => { 'id' => 1, 'name' => 'Within 1-2 days' },
+                               'urgency' => {'id' => 1, 'name' => 'Within 1-2 days'},
                                # # TODO: not yet implemented:
                                # "availability" => [{"id" => 1, "name" => "AM"}],
                                # "publish_until" => "2021-10-11",
@@ -34,11 +34,11 @@ RSpec.describe ContributionBlueprint do
                                'match_path' => nil,
                                'name' => contribution.name,
                                'location' => nil,
-                               'service_area' => { 'description' => contribution.service_area.description, 'id' => contribution.service_area.id, 'location' => { 'city' => contribution.service_area.location.city, 'county' => contribution.service_area.location.county, 'id' => contribution.service_area.location.id, 'neighborhood' => contribution.service_area.location.neighborhood, 'region' => contribution.service_area.location.region, 'state' => contribution.service_area.location.state, 'street_address' => contribution.service_area.location.street_address, 'zip' => contribution.service_area.location.zip }, 'name' => expected_area_name },
+                               'service_area' => {'description' => contribution.service_area.description, 'id' => contribution.service_area.id, 'location' => {'city' => contribution.service_area.location.city, 'county' => contribution.service_area.location.county, 'id' => contribution.service_area.location.id, 'neighborhood' => contribution.service_area.location.neighborhood, 'region' => contribution.service_area.location.region, 'state' => contribution.service_area.location.state, 'street_address' => contribution.service_area.location.street_address, 'zip' => contribution.service_area.location.zip}, 'name' => expected_area_name},
                                # "map_location" => "44.5,-85.1",
                                'title' => contribution.title,
                                'description' => contribution.description,
-                               'contact_types' => [{ 'id' => expected_contact_method.id, 'name' => expected_contact_method.name }]
+                               'contact_types' => [{'id' => expected_contact_method.id, 'name' => expected_contact_method.name}]
                            }]
     }
     result = ContributionBlueprint.render([contribution], root: 'contributions')

--- a/spec/blueprints/contribution_blueprint_spec.rb
+++ b/spec/blueprints/contribution_blueprint_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ContributionBlueprint do
                                'match_path' => nil,
                                'name' => contribution.name,
                                'location' => nil,
-                               'service_area' => { 'description' => contribution.service_area.description, 'id' => contribution.service_area.id,  'location' => { 'city' => contribution.service_area.location.city, 'county' => contribution.service_area.location.county, 'id' => contribution.service_area.location.id, 'neighborhood' => contribution.service_area.location.neighborhood, 'region' => contribution.service_area.location.region, 'state' => contribution.service_area.location.state, 'street_address' => contribution.service_area.location.street_address, 'zip' => contribution.service_area.location.zip }, 'name' => expected_area_name },
+                               'service_area' => { 'description' => contribution.service_area.description, 'id' => contribution.service_area.id, 'location' => { 'city' => contribution.service_area.location.city, 'county' => contribution.service_area.location.county, 'id' => contribution.service_area.location.id, 'neighborhood' => contribution.service_area.location.neighborhood, 'region' => contribution.service_area.location.region, 'state' => contribution.service_area.location.state, 'street_address' => contribution.service_area.location.street_address, 'zip' => contribution.service_area.location.zip }, 'name' => expected_area_name },
                                # "map_location" => "44.5,-85.1",
                                'title' => contribution.title,
                                'description' => contribution.description,

--- a/spec/blueprints/filter_type_blueprint_spec.rb
+++ b/spec/blueprints/filter_type_blueprint_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe FilterTypeBlueprint do
   describe 'render' do
     it 'can serialize a class that provides `.as_filter_types`, `#name`, and `#id`' do
       initial_data = [{id: 1, name: 'East Bay Township'}, {id: 2, name: 'Takoma'}, {id: 3, name: 'Wicomico County'}]
-      service_areas = initial_data.map {|data| ServiceArea.new(data)}
+      service_areas = initial_data.map { |data| ServiceArea.new(data) }
       class_double = double(ServiceArea)
       expect(class_double).to receive(:as_filter_types).and_return(service_areas)
 

--- a/spec/blueprints/filter_type_blueprint_spec.rb
+++ b/spec/blueprints/filter_type_blueprint_spec.rb
@@ -3,15 +3,15 @@ require 'rails_helper'
 RSpec.describe FilterTypeBlueprint do
   describe 'render' do
     it 'can serialize a class that provides `.as_filter_types`, `#name`, and `#id`' do
-      initial_data = [{ id: 1, name: 'East Bay Township' }, { id: 2, name: 'Takoma' }, { id: 3, name: 'Wicomico County' }]
+      initial_data = [{id: 1, name: 'East Bay Township'}, {id: 2, name: 'Takoma'}, {id: 3, name: 'Wicomico County'}]
       service_areas = initial_data.map {|data| ServiceArea.new(data)}
       class_double = double(ServiceArea)
       expect(class_double).to receive(:as_filter_types).and_return(service_areas)
 
       expected_data = [
-        { 'id' => 'ServiceArea[1]', 'name' => 'East Bay Township' },
-        { 'id' => 'ServiceArea[2]', 'name' => 'Takoma' },
-        { 'id' => 'ServiceArea[3]', 'name' => 'Wicomico County' }
+        {'id' => 'ServiceArea[1]', 'name' => 'East Bay Township'},
+        {'id' => 'ServiceArea[2]', 'name' => 'Takoma'},
+        {'id' => 'ServiceArea[3]', 'name' => 'Wicomico County'}
       ].to_json
       actual_data = FilterTypeBlueprint.render(class_double)
       expect(actual_data).to match(/#{expected_data}\z/)

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     preferred_contact_method { association :contact_method_email }
 
     trait :with_email do
-      preferred_contact_method { association :contact_method_email  }
+      preferred_contact_method { association :contact_method_email }
       email { Faker::Internet.email }
     end
 
@@ -15,7 +15,7 @@ FactoryBot.define do
     end
 
     trait :with_email_and_phone do
-      preferred_contact_method { association :contact_method_email  }
+      preferred_contact_method { association :contact_method_email }
       email { Faker::Internet.email }
       phone { Faker::PhoneNumber.phone_number }
     end

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe BaseForm do
     end
 
     context 'with an explicitly nil param' do
-      let(:params) {{ date: nil }}
+      let(:params) {{date: nil}}
 
       specify 'inputs show all params with defaults' do
         expect(inputs).to eq(string: nil, date: nil)
@@ -45,7 +45,7 @@ RSpec.describe BaseForm do
     end
 
     context 'with params given' do
-      let(:params) {{ string: 'a string', date: '2020-12-31' }}
+      let(:params) {{string: 'a string', date: '2020-12-31'}}
 
       it 'recognizes the given params' do
         expect(inputs).to eq(string: 'a string', date: Date.new(2020, 12, 31))

--- a/spec/forms/base_form_spec.rb
+++ b/spec/forms/base_form_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe BaseForm do
     let(:given_inputs) { result[1] }
 
     context 'with no params given' do
-      let(:params) {{}}
+      let(:params) { {} }
 
       it 'recognizes no params were given' do
         expect(inputs).to eq(string: nil, date: nil)
@@ -33,7 +33,7 @@ RSpec.describe BaseForm do
     end
 
     context 'with an explicitly nil param' do
-      let(:params) {{date: nil}}
+      let(:params) { {date: nil} }
 
       specify 'inputs show all params with defaults' do
         expect(inputs).to eq(string: nil, date: nil)
@@ -45,7 +45,7 @@ RSpec.describe BaseForm do
     end
 
     context 'with params given' do
-      let(:params) {{string: 'a string', date: '2020-12-31'}}
+      let(:params) { {string: 'a string', date: '2020-12-31'} }
 
       it 'recognizes the given params' do
         expect(inputs).to eq(string: 'a string', date: Date.new(2020, 12, 31))
@@ -54,11 +54,11 @@ RSpec.describe BaseForm do
     end
 
     context 'with a complete multi-part date param' do
-      let(:params) {{
+      let(:params) { {
         'date(1i)' => '2020',
         'date(2i)' => '12',
         'date(3i)' => '31',
-      }}
+      } }
 
       it 'recognizes the multi-part date was given' do
         expect(inputs).to eq(string: nil, date: Date.new(2020, 12, 31))
@@ -67,9 +67,9 @@ RSpec.describe BaseForm do
     end
 
     context 'with a partial multi-part date param' do
-      let(:params) {{
+      let(:params) { {
         'date(1i)' => '2020',
-      }}
+      } }
 
       it 'ignores the date' do
         expect(inputs).to eq(string: nil, date: nil)

--- a/spec/forms/community_resource_form_spec.rb
+++ b/spec/forms/community_resource_form_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CommunityResourceForm do
   let!(:location_type) { create :location_type }
-  let(:params) {{
+  let(:params) { {
     name: 'Free breakfast program',
     description: 'Feed the people!',
     publish_from: '1969-01-01',
@@ -13,7 +13,7 @@ RSpec.describe CommunityResourceForm do
     organization_attributes: {
       name: 'Black Panther Party',
     },
-  }}
+  } }
 
   describe 'creating a new community resource' do
     let(:community_resource) { CommunityResourceForm.build params }
@@ -73,9 +73,9 @@ RSpec.describe CommunityResourceForm do
   end
 
   describe 'updating an existing community resource' do
-    let!(:existing) { CommunityResourceForm.build(params).tap {|o| o.save! } }
+    let!(:existing) { CommunityResourceForm.build(params).tap { |o| o.save! } }
 
-    let(:update_params) {{
+    let(:update_params) { {
       id: existing.id,
       name: 'new name',
       description: 'new description',

--- a/spec/forms/community_resource_form_spec.rb
+++ b/spec/forms/community_resource_form_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe CommunityResourceForm do
   end
 
   describe 'updating an existing community resource' do
-    let!(:existing) { CommunityResourceForm.build(params).tap{|o| o.save! } }
+    let!(:existing) { CommunityResourceForm.build(params).tap {|o| o.save! } }
 
     let(:update_params) {{
       id: existing.id,

--- a/spec/forms/submission_form_spec.rb
+++ b/spec/forms/submission_form_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe SubmissionForm do
       # expect(submission.listings.first).to be_changed
       expect(submission.person.location).to be_changed
       expect(submission.person).to be_changed
-      expect(submission).to be_changed  # TODO: should submissions be editable?
+      expect(submission).to be_changed # TODO: should submissions be editable?
     end
 
     it 'applies new values to submission and nested objects' do

--- a/spec/forms/submission_form_spec.rb
+++ b/spec/forms/submission_form_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe SubmissionForm do
   let(:service_area)   { create :service_area }
   let(:questions)      { create_list :custom_form_question, 2 }
 
-  let(:categories) {[
+  let(:categories) { [
     create(:category, name: 'toys'),
     create(:category, name: 'groceries'),
-  ]}
+  ] }
 
   describe 'creating a new submission' do
-    let(:params) {{
+    let(:params) { {
       form_name: 'Offer_form',
       privacy_level_requested: 'anyone',
       service_area: service_area.id,
@@ -36,7 +36,7 @@ RSpec.describe SubmissionForm do
       responses_attributes: questions.map.with_index { |question, index|
         [question.id.to_s, "answer #{index + 1}"]
       }.to_h,
-    }}
+    } }
 
     subject(:submission) { SubmissionForm.build params }
 
@@ -227,7 +227,7 @@ RSpec.describe SubmissionForm do
     )}
     let(:existing_response) { create :submission_response, submission: existing_submission }
 
-    let(:params) {{
+    let(:params) { {
       id: existing_submission.id,
       form_name: 'Ask_form',
       service_area: existing_listing.service_area.id,
@@ -246,7 +246,7 @@ RSpec.describe SubmissionForm do
       responses_attributes: {
         existing_response.custom_form_question_id.to_s => 'updated answer',
       },
-    }}
+    } }
 
     let(:submission) { SubmissionForm.build params }
 

--- a/spec/lib/tasks/support/listing_converter_spec.rb
+++ b/spec/lib/tasks/support/listing_converter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ListingConverter do
 
   context 'without sub-categories' do
     let(:tags)        { %w[cash errands housing] }
-    let!(:categories) { tags.map{ |name| create :category, name: name }}
+    let!(:categories) { tags.map { |name| create :category, name: name }}
     let(:listing)     { create :listing, tag_list: tags }
 
     it 'removes all but one tag from the original listing' do
@@ -62,7 +62,7 @@ RSpec.describe ListingConverter do
     let!(:listing)     { create :listing, tag_list: %w[food meals] }
 
     it 'does not create any new listings' do
-      expect{ convert }.to_not change(Listing, :count)
+      expect { convert }.to_not change(Listing, :count)
     end
 
     it 'leaves the listing tags unchanged' do

--- a/spec/lib/tasks/support/listing_converter_spec.rb
+++ b/spec/lib/tasks/support/listing_converter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ListingConverter do
 
   context 'without sub-categories' do
     let(:tags)        { %w[cash errands housing] }
-    let!(:categories) { tags.map { |name| create :category, name: name }}
+    let!(:categories) { tags.map { |name| create :category, name: name } }
     let(:listing)     { create :listing, tag_list: tags }
 
     it 'removes all but one tag from the original listing' do
@@ -95,13 +95,13 @@ RSpec.describe ListingConverter do
 
   describe 'TagSplitter' do
     let(:splitter) { ListingConverter::TagSplitter.new(lineages) }
-    let(:lineages) {{
+    let(:lineages) { {
       'grandchild'  => %w[parent child grandchild],
       'child'       => %w[parent child],
       'other_child' => %w[parent other_child],
       'parent'      => %w[parent],
       'orphan'      => %w[orphan],
-    }}
+    } }
 
     subject { splitter.split tag_list }
 

--- a/spec/models/browse_filter_spec.rb
+++ b/spec/models/browse_filter_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe BrowseFilter do
-  let(:all_models) { ContributionType::TYPES.map(&:model)}
+  let(:all_models) { ContributionType::TYPES.map(&:model) }
   it 'ignores urgency levels if all urgency levels are checked because urgency levels are not fully implemented' do
     pending
     unmodified_scope = double

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Person, type: :model do
 
       it 'generates an error on the correct field' do
         person.valid?
-        expect(person.errors.messages).to eq({ phone: ["can't be blank"] })
+        expect(person.errors.messages).to eq({phone: ["can't be blank"]})
       end
     end
   end

--- a/spec/policies/nav_bar_policy_spec.rb
+++ b/spec/policies/nav_bar_policy_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe NavBarPolicy do
     context 'neighbor' do
       let(:user) { instance_double 'User', admin_role?: false, sys_admin_role?: false }
 
-      it { is_expected.to match_array %w[Feedback Logout]  }
+      it { is_expected.to match_array %w[Feedback Logout] }
 
       context 'in peer_to_peer mode' do
         let(:peer_to_peer?) { true }
@@ -32,12 +32,12 @@ RSpec.describe NavBarPolicy do
 
     context 'admin' do
       let(:user) { instance_double 'User', admin_role?: true, sys_admin_role?: false }
-      it { is_expected.to match_array %w[Contributions Matches Admin Feedback Logout]  }
+      it { is_expected.to match_array %w[Contributions Matches Admin Feedback Logout] }
     end
 
     context 'sys_admin' do
       let(:user) { instance_double 'User', admin_role?: false, sys_admin_role?: true }
-      it { is_expected.to match_array %w[Contributions Matches Admin Feedback Logout]  }
+      it { is_expected.to match_array %w[Contributions Matches Admin Feedback Logout] }
     end
   end
 end

--- a/spec/requests/announcements_spec.rb
+++ b/spec/requests/announcements_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe '/announcements', type: :request do
   let(:announcement) { create :announcement, is_approved: false }
-  let(:params) {{announcement: {
+  let(:params) { {announcement: {
     name: 'Ni una mas',
     description: 'Not one more',
     publish_from: Date.current,
     is_approved: true,
-  }}}
+  }} }
 
   describe 'GET /announcements' do
     it 'is accessible to guests' do

--- a/spec/requests/announcements_spec.rb
+++ b/spec/requests/announcements_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe '/announcements', type: :request do
   let(:announcement) { create :announcement, is_approved: false }
-  let(:params) {{ announcement: {
+  let(:params) {{announcement: {
     name: 'Ni una mas',
     description: 'Not one more',
     publish_from: Date.current,

--- a/spec/requests/community_resources_spec.rb
+++ b/spec/requests/community_resources_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe '/community_resources', type: :request do
   let!(:location_type) { create :location_type }
   let(:community_resource) { create :community_resource }
 
-  let(:params) {{ community_resource: {
+  let(:params) {{community_resource: {
     name: 'Free Breakfast Program',
     description: 'Food for the rev!',
     'publish_from(1i)' => '2020',
     'publish_from(2i)' => '12',
     'publish_from(3i)' => '31',
-    organization_attributes: { name: 'Black Panther Party' },
+    organization_attributes: {name: 'Black Panther Party'},
     location: {
       street_address: '123 Sesame Street',
       city: 'Kings Park',

--- a/spec/requests/community_resources_spec.rb
+++ b/spec/requests/community_resources_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe '/community_resources', type: :request do
   let!(:location_type) { create :location_type }
   let(:community_resource) { create :community_resource }
 
-  let(:params) {{community_resource: {
+  let(:params) { {community_resource: {
     name: 'Free Breakfast Program',
     description: 'Food for the rev!',
     'publish_from(1i)' => '2020',
@@ -18,7 +18,7 @@ RSpec.describe '/community_resources', type: :request do
       zip: '11754',
       location_type: location_type.id,
     }
-  }}}
+  }} }
 
   describe 'GET /community_resources' do
     before { create_list :community_resource, 2 }

--- a/spec/requests/contributions_spec.rb
+++ b/spec/requests/contributions_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe '/contributions', type: :request do
-  let(:valid_attributes) {{
+  let(:valid_attributes) { {
     location_attributes: {zip: '12345'},
     tag_list: ['', 'cash'],
-  }}
+  } }
 
-  let(:invalid_attributes) {{
+  let(:invalid_attributes) { {
     location_attributes: {zip: '12e45'},
-  }}
+  } }
 
   let(:user) { create(:user) }
 
@@ -102,7 +102,7 @@ RSpec.describe '/contributions', type: :request do
 
       expect(response.body).to match(/#{expected_area.name.to_json}/)
 
-      response_ids = JSON.parse(response.body).map { |hash| hash['id']}
+      response_ids = JSON.parse(response.body).map { |hash| hash['id'] }
       expect(response_ids).to include(both_tags_listing.id)
       expect(response_ids).to include(one_tag_listing.id)
       expect(response_ids).not_to include(both_tags_wrong_area_listing.id)

--- a/spec/requests/contributions_spec.rb
+++ b/spec/requests/contributions_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe '/contributions', type: :request do
   let(:valid_attributes) {{
-    location_attributes: { zip: '12345' },
+    location_attributes: {zip: '12345'},
     tag_list: ['', 'cash'],
   }}
 
   let(:invalid_attributes) {{
-    location_attributes: { zip: '12e45' },
+    location_attributes: {zip: '12e45'},
   }}
 
   let(:user) { create(:user) }
@@ -69,13 +69,13 @@ RSpec.describe '/contributions', type: :request do
       sign_in user
       ask = create(:ask, title: 'this is the ask title')
       offer = create(:offer, title: 'this is the offer title')
-      get contributions_url, params: { ContributionType: { 'Ask' => 1 } }
+      get contributions_url, params: {ContributionType: {'Ask' => 1}}
       expect(response.body).to match(ask.title)
       expect(response.body).not_to match(offer.title)
-      get contributions_url, params: { ContributionType: { 'Offer' => 1 } }
+      get contributions_url, params: {ContributionType: {'Offer' => 1}}
       expect(response.body).not_to match(ask.title)
       expect(response.body).to match(offer.title)
-      get contributions_url, params: { ContributionType: { 'Ask' => 1, 'Offer' => 1 } }
+      get contributions_url, params: {ContributionType: {'Ask' => 1, 'Offer' => 1}}
       expect(response.body).to match(ask.title)
       expect(response.body).to match(offer.title)
     end
@@ -96,8 +96,8 @@ RSpec.describe '/contributions', type: :request do
 
       # passing `as: json` to `get` does some surprising things to the request and its params that would break this test
       get contributions_url, {
-        params: { "Category[#{categories[0].id}]": 1, "Category[#{categories[1].id}]": 1, "ServiceArea[#{expected_area.id}]": 1 },
-        headers: { 'HTTP_ACCEPT' => 'application/json' }
+        params: {"Category[#{categories[0].id}]": 1, "Category[#{categories[1].id}]": 1, "ServiceArea[#{expected_area.id}]": 1},
+        headers: {'HTTP_ACCEPT' => 'application/json'}
       }
 
       expect(response.body).to match(/#{expected_area.name.to_json}/)

--- a/spec/requests/glossary_spec.rb
+++ b/spec/requests/glossary_spec.rb
@@ -28,7 +28,7 @@ describe '/glossary', type: :request do
       let(:new_html) { "<b>Word</b>: Definition" }
 
       it 'updates glossary_content of the system_setting object' do
-        patch glossary_url, params: { system_setting: { glossary_content: new_html } }
+        patch glossary_url, params: {system_setting: {glossary_content: new_html}}
         expect(response.status).to eq 302
         expect(system_setting.reload.glossary_content.to_s).to include new_html
       end

--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -1,17 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe '/listings', type: :request do
-  let(:valid_attributes) {{
+  let(:valid_attributes) { {
     location_attributes: {zip: '12345'},
     tag_list: ['', 'cash'],
     # name: Faker::Name.name,
     # email: Faker::Internet.email,
     # phone: Faker::PhoneNumber.phone_number
-  }}
+  } }
 
-  let(:invalid_attributes) {{
+  let(:invalid_attributes) { {
     location_attributes: {zip: '12e45'},
-  }}
+  } }
 
   before { sign_in create(:user, :admin) }
 
@@ -109,9 +109,9 @@ RSpec.describe '/listings', type: :request do
 
     context 'with valid parameters' do
       let(:new_street_address) { Faker::Address.street_address }
-      let(:new_attributes) {{
+      let(:new_attributes) { {
         location_attributes: {street_address: new_street_address, zip: Faker::Address.zip(state_abbreviation: 'MI')},
-      }}
+      } }
 
       before do
         # patch listing_url(listing), params: { listing: new_attributes }

--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe '/listings', type: :request do
   let(:valid_attributes) {{
-    location_attributes: { zip: '12345' },
+    location_attributes: {zip: '12345'},
     tag_list: ['', 'cash'],
     # name: Faker::Name.name,
     # email: Faker::Internet.email,
@@ -10,7 +10,7 @@ RSpec.describe '/listings', type: :request do
   }}
 
   let(:invalid_attributes) {{
-    location_attributes: { zip: '12e45' },
+    location_attributes: {zip: '12e45'},
   }}
 
   before { sign_in create(:user, :admin) }
@@ -78,14 +78,14 @@ RSpec.describe '/listings', type: :request do
       it 'creates a new Listing and Location' do
         pending 'relationship between contribution form and addresses is tbd'
         expect {
-          post listings_url, params: { listing: valid_attributes }
+          post listings_url, params: {listing: valid_attributes}
         }.to  change(Listing, :count).by(1)
          .and change(Location, :count).by(1)
       end
 
       it 'redirects to the created listing' do
         pending 'relationship between contribution form and addresses is tbd'
-        post listings_url, params: { listing: valid_attributes }
+        post listings_url, params: {listing: valid_attributes}
         expect(response).to redirect_to(listing_url(Listing.last))
       end
     end
@@ -93,12 +93,12 @@ RSpec.describe '/listings', type: :request do
     context 'with invalid parameters' do
       it 'does not create a new Listing' do
         expect {
-          post listings_url, params: { listing: invalid_attributes }
+          post listings_url, params: {listing: invalid_attributes}
         }.to change(Listing, :count).by(0)
       end
 
       it "renders a successful response (i.e. to display the 'new' template)" do
-        post listings_url, params: { listing: invalid_attributes }
+        post listings_url, params: {listing: invalid_attributes}
         expect(response).to be_successful
       end
     end
@@ -110,7 +110,7 @@ RSpec.describe '/listings', type: :request do
     context 'with valid parameters' do
       let(:new_street_address) { Faker::Address.street_address }
       let(:new_attributes) {{
-        location_attributes: { street_address: new_street_address, zip: Faker::Address.zip(state_abbreviation: 'MI') },
+        location_attributes: {street_address: new_street_address, zip: Faker::Address.zip(state_abbreviation: 'MI')},
       }}
 
       before do
@@ -131,7 +131,7 @@ RSpec.describe '/listings', type: :request do
     context 'with invalid parameters' do
       it "renders a successful response (i.e. to display the 'edit' template)" do
         pending 'relationship between contribution form and addresses is tbd'
-        patch listing_url(listing), params: { listing: invalid_attributes }
+        patch listing_url(listing), params: {listing: invalid_attributes}
         expect(response).to be_successful
       end
     end

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "/people", type: :request do
 
   describe "POST /create" do
     it "can render" do
-      post "/people", params: { person: FactoryBot.attributes_for(:person) }
+      post "/people", params: {person: FactoryBot.attributes_for(:person)}
       expect(response).to be_successful
     end
   end
@@ -54,7 +54,7 @@ RSpec.describe "/people", type: :request do
     let(:person) { FactoryBot.create(:person) }
 
     it "updates the person" do
-      patch "/people/#{person.id}", params: { person: { name: "Aud Torvingen" } }
+      patch "/people/#{person.id}", params: {person: {name: "Aud Torvingen"}}
       person.reload
       expect(person.name).to eq("Aud Torvingen")
     end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "/users", type: :request do
       skip "To be implemented when we have a #create action."
 
       expect {
-        post "/users", params: { user: FactoryBot.attributes_for(:user) }
+        post "/users", params: {user: FactoryBot.attributes_for(:user)}
       }.to change {
         User.count
       }.by(1)
@@ -51,7 +51,7 @@ RSpec.describe "/users", type: :request do
     let(:user) { FactoryBot.create(:user, role: "unset") }
 
     it "updates the user" do
-      patch "/users/#{user.id}", params: { user: { email: "atorvingen@example.com" } }
+      patch "/users/#{user.id}", params: {user: {email: "atorvingen@example.com"}}
 
       # Manually confirming because it's required by Devise when changing a user's email address
       user.reload.confirm
@@ -60,7 +60,7 @@ RSpec.describe "/users", type: :request do
 
     context "when changing roles" do
       it "allows admins to change a user's role" do
-        patch "/users/#{user.id}", params: { user: { role: "neighbor" } }
+        patch "/users/#{user.id}", params: {user: {role: "neighbor"}}
 
         expect(user.reload.role).to eq("neighbor")
       end


### PR DESCRIPTION
### Why
Building on #935, fixes a bunch of violations related to `spaces` and enables corresponding rules.

### What
See the commit list for the rules tackled in this PR. The commit comments include links to the corresponding rubocop docs.

Includes one override of StandardRB rules: their configuration of `Layout/ExtraSpacing` does not allow extra spaces anywhere. I'm recommending we set `AllowForAlignment: true`, which gives authors the freedom to vertically align code when we feel that alignment improves readability.

Some rules worth noting:
* Spaces are _required_ around braces that represent _code blocks_ `-> { ... }`.
* Spaces are _not allowed_ after the opening brace and before the closing brace of _hash literals_ `{x: :y}`.
* Spaces are _not allowed_ after/before opening/closing parentheses `()`.
* Spaces are _not allowed_ after/before opening/closing brackets `[]`.
* Spaces are _required_ around operators ` + `.
* Spaces are _required_ around param default equal signs ` = `.


### How
See each individual commit diff and comments.

### Testing
Relying on our existing suite to catch any regressions.

### Next Steps
?

### Outstanding Questions, Concerns and Other Notes
Open to thoughts about any of the rules enabled here, and particularly the customization.

### Pre-Merge Checklist
- [x] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [x] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
