### PR TITLE
Rubocop single line methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,6 @@ Style/StringLiteralsInInterpolation:
 
 Style/SingleLineMethods:
   Enabled: false
+
+Style/EmptyMethod:
+  EnforcedStyle: compact

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Metrics:
   # Disabled in Standard by default
   Enabled: true
 
+Layout/EmptyLineBetweenDefs:
+  AllowAdjacentOneLineDefs: true
+
 Layout/ExtraSpacing:
   AllowForAlignment: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,6 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   Enabled: false
+
+Style/SingleLineMethods:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,20 +21,6 @@ Layout/EmptyLineAfterMagicComment:
     - 'spec/interactions/generate_landing_page_json_spec.rb'
     - 'spec/models/organization_spec.rb'
 
-# Offense count: 19
-# Cop supports --auto-correct.
-# Configuration parameters: EmptyLineBetweenMethodDefs, EmptyLineBetweenClassDefs, EmptyLineBetweenModuleDefs, AllowAdjacentOneLineDefs, NumberOfEmptyLines.
-Layout/EmptyLineBetweenDefs:
-  Exclude:
-    - 'app/controllers/announcements_controller.rb'
-    - 'app/controllers/community_resources_controller.rb'
-    - 'app/controllers/glossary_controller.rb'
-    - 'app/policies/announcement_policy.rb'
-    - 'app/policies/application_policy.rb'
-    - 'app/policies/community_resource_policy.rb'
-    - 'app/policies/contribution_policy.rb'
-    - 'app/policies/glossary_policy.rb'
-
 # Offense count: 8
 # Cop supports --auto-correct.
 Layout/EmptyLines:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -498,9 +498,3 @@ Style/SafeNavigation:
     - 'app/models/importers/custom_form_question_importer.rb'
     - 'app/policies/application_policy.rb'
     - 'spec/models/organization_spec.rb'
-
-# Offense count: 66
-# Cop supports --auto-correct.
-# Configuration parameters: AllowIfMethodIsEmpty.
-Style/SingleLineMethods:
-  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -350,13 +350,6 @@ Style/EmptyLiteral:
   Exclude:
     - 'app/controllers/listings_controller.rb'
 
-# Offense count: 42
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: compact, expanded
-Style/EmptyMethod:
-  Enabled: false
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Style/GlobalStdStream:


### PR DESCRIPTION
### Why
Building on #935, configures rules related to single-line and empty method definitions

### What
Standard doesn't allow for single-line methods, but i'm proposing here that they can be useful in certain situations. Some of our policy files are good examples.

Moreover, single-line methods don't often coming up as an issue in our codebase or in the wild.

As such, i'm proposing:
* Allow single-line methods
* Allow empty methods, enforcing a `compact`, single-line style
* Allow adjacent single-line methods w/o an empty line between them

### Testing
Relying on our existing suite to catch any regressions.

### Next Steps
?

### Outstanding Questions, Concerns and Other Notes
?

### Pre-Merge Checklist
- [x] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [x] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
