### PR TITLE
Rubocop string literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,6 @@ inherit_from:
 Metrics:
   # Disabled in Standard by default
   Enabled: true
+
+Style/StringLiterals:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,6 @@ Metrics:
 
 Style/StringLiterals:
   Enabled: false
+
+Style/StringLiteralsInInterpolation:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -865,19 +865,6 @@ Style/SafeNavigation:
 Style/SingleLineMethods:
   Enabled: false
 
-# Offense count: 8
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiteralsInInterpolation:
-  Exclude:
-    - 'app/helpers/application_helper.rb'
-    - 'app/models/donation.rb'
-    - 'app/models/importers/base_importer.rb'
-    - 'app/models/importers/custom_form_question_importer.rb'
-    - 'app/models/match.rb'
-    - 'db/scripts/tuple_counts.rb'
-
 # Offense count: 41
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -865,13 +865,6 @@ Style/SafeNavigation:
 Style/SingleLineMethods:
   Enabled: false
 
-# Offense count: 2037
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiterals:
-  Enabled: false
-
 # Offense count: 8
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.


### PR DESCRIPTION
### Why
Building on #935, disables Standard rules around string literals.

### What
Standard requires all string literals to use double-qoutes instead of single-quotes.

This makes sense and is easily auto-corrected _but_ i'm not sure of the value in enforcing this.

The argument that using double-quotes saves time (in trying to guess whether a string will need interpolation in the future, or when that does change) is sound. However, any author who ascribes to this is free to exclusively use double-quotes.

The downside of enforcing the Standard double-quotes is a significant disruption to git history caused by this pervasive auto-correction.
That in itself feels like enough reason to just disable this rule.

### Testing
Relying on our existing suite to catch any regressions.

### Next Steps
?

### Outstanding Questions, Concerns and Other Notes
Really curious the team's thoughts on this.

### Pre-Merge Checklist
- [x] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [x] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
