### PR TITLE
Fix bug in Claiming introduced in acd210de08

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ We're still in the [initial development phase](https://www.jering.tech/articles/
 
 This changelog also serves to acknowledge the incredible people who've contributed brilliance, effort and being. Their handles are listed under the first release they each  touched. 💗🙏🏾
 
+## [Unreleased]
+### Bugfixes
+* Fix breakage in claiming a contribution #946
+
 ## [0.5.0] - 2021-04-08
 ### Enhancements
 * Change address field on community resource form from dropdown to text input #900, #909, #923

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -18,7 +18,8 @@ class ClaimsController < ApplicationController
   def create
     ClaimContribution.run!(params[:claim].merge(
       contribution: params[:contribution_id],
-      current_user: current_user
+      current_user: context.user,
+      organization: context.host_organization
     ))
     redirect_to contributions_path, notice: 'Claim was successful!'
   end

--- a/app/interactions/claim_contribution.rb
+++ b/app/interactions/claim_contribution.rb
@@ -5,6 +5,7 @@ class ClaimContribution < ActiveInteraction::Base
   string :message
   record :contribution, class: Listing
   object :current_user, class: User
+  object :organization
 
   def execute
     # TODO: Need to handle race conditions to prevent creating multiple matches for same contribution
@@ -37,6 +38,7 @@ class ClaimContribution < ActiveInteraction::Base
       contribution: contribution,
       peer_alias: peer_alias,
       message: message,
+      organization: organization,
       user: current_user
     )
   end

--- a/spec/interactions/claim_contribution_spec.rb
+++ b/spec/interactions/claim_contribution_spec.rb
@@ -1,32 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe ClaimContribution do
-  before do
-    allow(MatchContribution).to receive(:run!)
-    allow(EmailPeer).to receive(:run!)
-  end
-
   let(:contribution) { create(:listing) }
   let(:user) { create(:user, :with_person, email: 'user_email@example.com') }
 
-  before do
+  let(:claim_contribution) do
     ClaimContribution.run!(
       contribution: contribution.id,
       current_user: user,
+      organization: build(:organization),
       peer_alias: 'alias',
       message: 'message',
     )
   end
 
-  it "matches contribution and sends an email to peer", :aggregate_failures do
-    expect(MatchContribution).to have_received(:run!)
-    expect(EmailPeer).to have_received(:run!)
+  it "matches the contribution" do
+    expect { claim_contribution }.to change(Match, :count).by(1)
+    expect(contribution.matches.count).to be(1)
+  end
+
+  it "sends an email to the peer" do
+    expect { claim_contribution }.to change(ActionMailer::Base.deliveries, :count).by(1)
   end
 
   context "when current user has no person record" do
     let(:user) { create(:user, email: 'user_email@example.com', person: nil) }
 
     it "creates a person" do
+      claim_contribution
+
       expect(user.reload.person).to have_attributes(
         user: user,
         email: user.email,


### PR DESCRIPTION
### Why
Fixes a [bug](https://mutual-aid-app.slack.com/archives/C01LSKPJZNW/p1618666427000700) in peer-to-peer claims.

### What
acd210de08 introduced a bug where `Organization` was added as a required argument to `EmailPeer`, but not
supplied by `ClaimContribution` and `ClaimsController`.

### Testing
This bug went uncaught because `claim_contribution_spec` was mocking EmailPeer. Changing the spec to let `ClaimContribution` call composite interactions as it normally would surfaces any such integration problems.

### Next Steps
?

### Outstanding Questions, Concerns and Other Notes
?

### Pre-Merge Checklist
- [x] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [x] Documentation and comments have been added to the codebase where required
- [x] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
