### PR TITLE
Introduce ToBoolean refinement to replace YAML.load

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using ToBoolean
+
 class ApplicationController < ActionController::Base
   include Authorization
 
@@ -12,7 +14,7 @@ class ApplicationController < ActionController::Base
 
   def set_admin_status
     # FIXME: replace uses of @admin_status with pundit
-    @admin_status = params[:admin] ? YAML.load(params[:admin]) : current_user&.admin_role? # allows admin user to simulate with param=false
+    @admin_status = params[:admin] ? params[:admin].to_boolean : current_user&.admin_role? # allows admin user to simulate with param=false
   end
 
   def set_system_setting

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using ToBoolean
+
 class MatchesController < AdminController
   before_action :set_match, only: %i[edit update destroy]
 
@@ -104,7 +106,7 @@ class MatchesController < AdminController
 
     @communication_logs = CommunicationLog.where(match: @match)
 
-    @edit_connection_mode = YAML.load(params[:edit_connection_mode].to_s)
+    @edit_connection_mode = params[:edit_connection_mode].to_boolean
   end
 
   def match_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using ToBoolean
+
 module ApplicationHelper
   require "#{Rails.root}/app/helpers/index_action_buttons.rb"
   require "#{Rails.root}/app/helpers/communication_log_buttons.rb"
@@ -7,7 +9,8 @@ module ApplicationHelper
   include CommunicationLogButtons
   include IndexActionButtons
 
-  def yes_no(boolean)
+  def yes_no(boolean_or_string)
+    boolean = boolean_or_string.to_boolean
     "<span class='#{boolean ? "fa fa-check-circle has-text-success" : "fa fa-ban"}'></span>".html_safe
   end
 

--- a/app/models/importers/custom_form_question_importer.rb
+++ b/app/models/importers/custom_form_question_importer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using ToBoolean
+
 class Importers::CustomFormQuestionImporter < Importers::BaseImporter
   def klasses_array
     [CustomFormQuestion]
@@ -25,7 +27,7 @@ class Importers::CustomFormQuestionImporter < Importers::BaseImporter
     locale = row['locale'] || 'en' # rubocop:todo Lint/UselessAssignment
     form_type = row['form_type']
     input_type = row['input_type'] || 'string'
-    is_required = YAML.load(row['is_required'].to_s)
+    is_required = row['is_required'].to_boolean
     display_order = row['display_order'].present? ? row['display_order'].to_i : 10
     hint_text = row['hint_text']
     option_list = row['option_list'].present? ? row['option_list'].split(';') : []

--- a/app/models/importers/submission_response_importer.rb
+++ b/app/models/importers/submission_response_importer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using ToBoolean
+
 class Importers::SubmissionResponseImporter < Importers::BaseImporter
   def initialize(current_user, form_type, categories_question_name = nil)
     require "#{Rails.root}/db/scripts/tuple_counts.rb"
@@ -202,7 +204,7 @@ class Importers::SubmissionResponseImporter < Importers::BaseImporter
     if ['Yes', 'No', 'Maybe'].include?(response_value)
       if responses.none?
         @new_records_count += 1
-        response = responses.first_or_create!(string_response: response_value, boolean_response: YAML.load(response_value.to_s))
+        response = responses.first_or_create!(string_response: response_value, boolean_response: response_value.to_boolean)
       else
         response = responses.last
         log = 'GOT DUPE'
@@ -244,7 +246,7 @@ class Importers::SubmissionResponseImporter < Importers::BaseImporter
     listings = []
     category_headers = CustomFormQuestion.translated_name_stem('_category_').where.not('mobility_string_translations.value ILIKE ? OR  mobility_string_translations.value ILIKE ?', '%_funding%', '%_description')
     category_headers.each do |category_cfq|
-      answer = YAML.load(row[category_cfq.name].to_s)
+      answer = row[category_cfq.name].to_boolean
       if answer
         category_name = category_cfq.name.downcase.gsub('offer_category_', '').gsub('ask_category_', '')
         category = Category.where(name: category_name).first_or_create! # rubocop:todo Lint/UselessAssignment

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+using ToBoolean
+
 class Match < ApplicationRecord
   belongs_to :receiver, polymorphic: true, inverse_of: :matches_as_receiver
   belongs_to :provider, polymorphic: true, inverse_of: :matches_as_provider
@@ -41,7 +43,7 @@ class Match < ApplicationRecord
 
   def self.follow_up_status(follow_up_status)
     needs_follow_up = self.needs_follow_up
-    if YAML.load(follow_up_status) == false
+    if follow_up_status.to_boolean == false
       where.not(id: needs_follow_up)
     else
       needs_follow_up

--- a/app/models/submission_response.rb
+++ b/app/models/submission_response.rb
@@ -6,21 +6,15 @@ class SubmissionResponse < ApplicationRecord
 
   def name
     # self.public_send(Question::INPUT_TYPES_AND_STORAGE[question.input_type])
-    name = nil
     [
       string_response,
       text_response,
-      YAML.load(boolean_response.to_s),
+      boolean_response.to_s,
       integer_response.to_s,
-      array_response.join(', '),
+      array_response&.join(', '),
       date_response&.strftime('%Y-%m-%d'),
-      datetime_response&.strftime('%Y-%m-%d @ %l:%m')
-    ].each do |string|
-      if string.present?
-        name = string # FIXME: this will find the _last_ present string, is that what we want?
-      end
-    end
-    name
+      datetime_response&.strftime('%Y-%m-%d @%l:%M%P')
+    ].find(&:present?)
   end
 
   # def input_type

--- a/app/refinements/to_boolean.rb
+++ b/app/refinements/to_boolean.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Provides a way to cast to boolean
+#
+# Returns true if given any string or symbol that, stripped and downcased, matches:
+#   1. True values recognized by YAML.load: %w[y, yes, true, on] (https://yaml.org/type/bool.html)
+#   2. The opposites of ActiveRecord::Type::Boolean::FALSE_VALUES -- %w[false, 0, f, off]
+# Returns nil if given nil or a blank string
+# Returns self if given a boolean
+# Returns false given any other string or symbol
+#
+module ToBoolean
+  refine String do
+    def to_boolean
+      blank? ? nil : strip.downcase.in?(%w[true yes on t y 1])
+    end
+  end
+
+  refine Symbol do
+    def to_boolean
+      to_s.to_boolean
+    end
+  end
+
+  refine(NilClass)   { def to_boolean; self end }
+  refine(TrueClass)  { def to_boolean; self end }
+  refine(FalseClass) { def to_boolean; self end }
+end

--- a/app/views/submissions/_submission_responses.html.erb
+++ b/app/views/submissions/_submission_responses.html.erb
@@ -5,7 +5,7 @@
   <% r = response %>
   <% question = r.custom_form_question %>
 
-  <% if params && YAML.load(params[:admin].to_s) %>
+  <% if context.can_admin? %>
     <% if r %>
       <% response_link = link_to(r.id, edit_submission_response_path(r.id)) %>
       Q<%= link_to(question.id,

--- a/app/views/submissions/_submission_responses.html.erb
+++ b/app/views/submissions/_submission_responses.html.erb
@@ -31,7 +31,7 @@
       <% elsif ["boolean", "radio"].include?(input_type) %>
         <% unedited_response = r.send(question_field_name(input_type)).to_s.html_safe %>
         <li><em><%= question.name.html_safe %><br/></em></li>
-        <%# puts "RESPONSE_id=#{r.id}...unedited: #{unedited_response}...boolean: #{r.send("boolean_response")&.to_s&.html_safe}(#{yes_no(YAML.load(response.to_s))})...#{r.inspect}" %>
+        <%# puts "RESPONSE_id=#{r.id}...unedited: #{unedited_response}...boolean: #{r.send("boolean_response")&.to_s&.html_safe}(#{yes_no(response)})...#{r.inspect}" %>
         <% if input_type == "radio" &&
             question.option_list != ["Yes", "No"] &&
             question.option_list != ["yes", "no"] &&
@@ -48,16 +48,16 @@
                 question.option_list == ["yes", "no"] ||
                 question.option_list == ["true", "false"] ||
                 question.option_list == ["True", "False"]) %>
-          <%# puts "RADIO 2: #{yes_no(YAML.load(response.to_s))}" %>
+          <%# puts "RADIO 2: #{yes_no(response)}" %>
           <% response = unedited_response %>
           <ul>
-            <li style="list-style-type:none;"><%= response_link %><strong><%= yes_no(YAML.load(response)) %></strong></li> (<%#= unedited_response %>)
+            <li style="list-style-type:none;"><%= response_link %><strong><%= yes_no(response) %></strong></li> (<%#= unedited_response %>)
           </ul>
         <% else %>
-          <%# puts "ELSE: #{yes_no(YAML.load(response.to_s))}" %>
+          <%# puts "ELSE: #{yes_no(response)}" %>
           <% response = r.send("boolean_response").to_s.html_safe %>
           <ul>
-            <li style="list-style-type:none;"><%= response_link %><strong><%= yes_no(YAML.load(response.to_s)) %></strong></li>
+            <li style="list-style-type:none;"><%= response_link %><strong><%= yes_no(response) %></strong></li>
           </ul>
         <% end %>
         <!--<br>-->

--- a/spec/models/submission_response_spec.rb
+++ b/spec/models/submission_response_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal
+
+require 'rails_helper'
+
+RSpec.describe SubmissionResponse, type: :model do
+  describe '#name' do
+    let(:inputs) do
+      {
+        string_response: nil,
+        text_response: nil,
+        boolean_response: nil,
+        integer_response: nil,
+        array_response: nil,
+        date_response: nil,
+        datetime_response: nil
+      }
+    end
+
+    subject { (build :submission_response, **inputs).name }
+
+    context 'with a string response' do
+      before { inputs[:string_response] = 'stringy!' }
+
+      it { is_expected.to eq 'stringy!' }
+    end
+
+    context 'with a boolean response' do
+      before { inputs[:boolean_response] = true }
+
+      it { is_expected.to eq 'true' }
+    end
+
+    context 'with an array response' do
+      before { inputs[:array_response] = %w[two responses] }
+
+      it { is_expected.to eq 'two, responses' }
+    end
+
+    context 'with a date response' do
+      before { inputs[:date_response] = Date.new(2020, 4, 1) }
+
+      it { is_expected.to eq '2020-04-01' }
+    end
+
+    context 'with a datetime response' do
+      before { inputs[:datetime_response] = DateTime.new(2020, 4, 1, 15, 33) }
+
+      it { is_expected.to eq '2020-04-01 @ 3:33pm' }
+    end
+  end
+end

--- a/spec/refinements/to_boolean_spec.rb
+++ b/spec/refinements/to_boolean_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+using ToBoolean
+
+RSpec.describe ToBoolean do
+  describe 'recognized truthy strings' do
+    %w[
+      true
+      truE
+      t
+      yes
+      y
+      on
+      1
+    ].each do |value|
+      padded_value = "'#{value}'".ljust(10)
+
+      example "#{padded_value} => true" do
+        expect(value.to_boolean).to be true
+      end
+    end
+  end
+
+  describe 'blank strings and nil' do
+    example("nil => nil") { expect(nil.to_boolean).to be nil }
+    example("' ' => nil") { expect(' '.to_boolean).to be nil }
+    example("''  => nil") { expect(''.to_boolean).to  be nil }
+  end
+
+  describe 'truthy string with surrounding whitspace' do
+    example("'true ' => true") { expect('true '.to_boolean).to be true }
+    example("' yes ' => true") { expect(' yes '.to_boolean).to be true }
+  end
+
+  describe 'booleans' do
+    example('true  => true')  { expect(true.to_boolean).to  be true }
+    example('false => false') { expect(false.to_boolean).to be false }
+  end
+
+  describe 'symbols' do
+    example(':TruE => true')  { expect(:TruE.to_boolean).to be true }
+    example(':null => false') { expect(:null.to_boolean).to be false }
+  end
+
+  describe 'any other strings' do
+    %w[
+      unclear
+      mistyped
+      untrue
+      false
+      f
+      0
+      n
+      etc
+    ].each do |value|
+      padded_value = "'#{value}'".ljust(10)
+
+      example "#{padded_value} => false" do
+        expect(value.to_boolean).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Why
As i was working through rubocop offenses, [`Security/YAML.load`](https://docs.rubocop.org/rubocop/cops_security.html#securityyamlload) surfaced in several places. While the easy fix for this is to use `.safe_load` instead, i was also curious why we were using YAML in the first place.

It appears we are using `YAML.load` as a way to convert a string to a boolean. While this works, i don't find it to be intention revealing. This PR introduces an alternate way to solve this.

### What
- [x] Introduces a `ToBoolean` [refinement](https://devdocs.io/ruby~2.7/syntax/refinements_rdoc) allowing us to  cast strings and symbols by calling `.to_boolean`.
- [x] Refactor the `yes_no` helper to accept either a string or a boolean and use `.to_boolean` internally.
- [x] Refactor `SubmissionResponse#name` which i believe does not need to be coercing `boolean_response`.
- [x] Refactor `_submission_responses.html.erb` to use `context.can_admin?` instead of `YAML.load`.
- [x] Refactor all other uses of `YAML.load` to use the new refinement.

### API design
I considered three alternative APIs:
1. A utility method such as `Util.to_boolean`. I usaully prefer the explicitness of this approach over modifying ruby objects, but in this instance, `.to_boolean` felt like a natural additional, similar to other casting methods such as `.to_i`, `to_f` etc.
2. Monkey-patch, which would lead to the same `.to_boolean` interface, but without the need to invoke `using ToBoolean`. This is a more well-known approach but comes with all the issues of monkey-patching, such as lack of transparency.
3. Monkey-patch with a refinement, which has the benefits of better isolation/encapsulation, explicitness and transparency, at the cost of a little more boilerplate. I also found another drawback: `using` doesn't work in erb templates; however this can be circumvented by pushing logic into helpers or presenters (as we do here in the `yes_no` helper).

### `.to_boolean` implementation
This implementation recognizes truthy strings from the set of the following:
* Values recognized as true by [YAML.load](https://yaml.org/type/bool.html).
* The *opposites* of values in `ActiveRecord::Type::Boolean::FALSE_VALUES`.
* Stripped, case-insensitive versions of both the above.

Importantly, there are functional differences from both YAML.load and ActiveRecord. This implementation is an accept-list of truthy strings, making all other strings false (except "" and nil, which return nil).

This is the opposite of AR casting, which is an accept-list of _falsey_ strings, and other strings are considered truthy. I feel it's usually more important to strictly recognize _truthy_ strings than falsey strings. Eg,
`params[:admin].to_boolean` should only return true when it exactly matches a known true value.

YAML.load has accept-lists for both truthy and falsey values, returning a string for anything unrecognized, so this implementation differs in defaulting unrecognized strings to false.

I think these differences are to be expected. The conversion from string to boolean is very contextual and i suspect this is why there isn't a standard `.to_b` implemented in ruby. I'm hoping the rules chosen here are appropriate for our common use cases.

### Testing
Added:
- [x] `spec/refinements/to_boolean_spec.rb`
- [x] `spec/models/submission_response_spec.rb`

### Next Steps
- [ ] There may be other places we can use `.to_boolean`. I've only converted places that were using `YAML.load`

### Outstanding Questions, Concerns and Other Notes
* See inline comments for some specific questions
* ?

### Security
I believe the pre-existing use of `YAML.load` was a significant attack vector because we were using it to convert user input in several places. See [this article](http://tenderlovemaking.com/2013/02/06/yaml-f7u12.html) for details.

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [x] Documentation and comments have been added to the codebase where required
- [x] Entry added to CHANGELOG.md if appropriate
- [x] Outstanding questions and concerns have been resolved
- [x] Any next steps have been turned into Issues or Discussions as appropriate
