### PR TITLE
Spike use of presenters during serialization

### DIFF
--- a/app/blueprints/contribution_blueprint.rb
+++ b/app/blueprints/contribution_blueprint.rb
@@ -16,14 +16,10 @@ class ContributionBlueprint < Blueprinter::Base
     contribution.created_at.to_f * 1000 # Javascript wants miliseconds, not seconds
   end
   field :type, name: :contribution_type
-  field :profile_path do |contribution, options|
-    options[:profile_path]&.call(contribution.person_id)
-  end
-  field :view_path do |contribution, options|
-    options[:view_path]&.call(contribution.id)
-  end
-  field :match_path do |contribution, options|
-    options[:match_path]&.call(contribution.id)
-  end
+  field :view_path
   association :person, blueprint: PersonBlueprint
+
+  # FIXME: profile_path and match_path appear to be unused; remove from here and front end
+  field(:profile_path) { nil }
+  field(:match_path) { nil }
 end

--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -8,7 +8,7 @@ class ContributionsController < ApplicationController
   def index
     @filter_types = FilterTypeBlueprint.render([ContributionType, Category, ServiceArea, UrgencyLevel, ContactMethod])
     filter = BrowseFilter.new(filter_params)
-    @contributions = ContributionBlueprint.render(filter.contributions, contribution_blueprint_options)
+    @contributions = ContributionBlueprint.render(ContributionPresenter.map(filter.contributions, self))
     respond_to do |format|
       format.html
       format.json { render inline: @contributions }
@@ -43,12 +43,6 @@ class ContributionsController < ApplicationController
 
   def peer_to_peer_mode?
     @system_setting.peer_to_peer?
-  end
-
-  def contribution_blueprint_options
-    options = {}
-    options[:view_path] = ->(id) { contribution_path(id) }
-    options
   end
 
   def filter_params

--- a/app/javascript/pages/browse/ListBrowser.vue
+++ b/app/javascript/pages/browse/ListBrowser.vue
@@ -33,7 +33,7 @@
             <a :href="contribution.view_path" class="button icon-list is-primary"><span class=""> View</span></a>
           </div>
         </td>
-        <td>{{ contribution.person.name.split(" (")[0] }}</td>
+        <td>{{ contribution.person.name }}</td>
 <!--        <td>{{ contribution.title }}</td>-->
       </tr>
     </table>

--- a/app/javascript/pages/browse/TileListItem.vue
+++ b/app/javascript/pages/browse/TileListItem.vue
@@ -33,7 +33,7 @@
             {{ service_area.name }}
           </div>
           <div>
-            {{ `From: ${person.name.split(" (")[0]}` }}
+            {{ `From: ${person.name}` }}
 
           </div>
         </div>

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -3,6 +3,10 @@ class BasePresenter < SimpleDelegator
   delegate :context, to: :h
   alias_method :object, :__getobj__
 
+  def self.map collection, view_context
+    collection.map { |object| new(object, view_context) }
+  end
+
   def initialize object, view_context
     super object
     @h = view_context

--- a/app/presenters/contribution_presenter.rb
+++ b/app/presenters/contribution_presenter.rb
@@ -1,0 +1,5 @@
+class ContributionPresenter < BasePresenter
+  def view_path
+    h.contribution_path id
+  end
+end

--- a/app/presenters/contribution_presenter.rb
+++ b/app/presenters/contribution_presenter.rb
@@ -2,4 +2,8 @@ class ContributionPresenter < BasePresenter
   def view_path
     h.contribution_path id
   end
+
+  def person
+    PersonPresenter.new(super, h)
+  end
 end

--- a/app/presenters/person_presenter.rb
+++ b/app/presenters/person_presenter.rb
@@ -1,0 +1,11 @@
+class PersonPresenter < BasePresenter
+  def name
+    policy.read? ? super : nil
+  end
+
+  private
+
+  def policy
+    @policy ||= PersonPolicy.new context, object
+  end
+end

--- a/spec/blueprints/contribution_blueprint_spec.rb
+++ b/spec/blueprints/contribution_blueprint_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ContributionBlueprint do
     )
   end
   let(:presenter) do
-    ContributionPresenter.new(contribution, double('ViewContext', contribution_path: '/fake/contribution/path'))
+    ContributionPresenter.new(contribution, double('ViewContext', contribution_path: '/fake/contribution/path', context: Context.new))
   end
   let(:expected_contact_method) { contribution.person.preferred_contact_method }
   it 'returns reasonable data by default' do
@@ -36,7 +36,7 @@ RSpec.describe ContributionBlueprint do
                                'profile_path' => nil,
                                'match_path' => nil,
                                'name' => contribution.name,
-                               'person' => { 'id' => contribution.person.id, 'name' => contribution.person.name, 'email' => contribution.person.email,
+                               'person' => { 'id' => contribution.person.id, 'name' => nil, 'email' => contribution.person.email,
                                              'phone' => contribution.person.phone, 'skills' =>  contribution.person.skills,
                                              'preferred_contact_method' => { 'id' => contribution.person.preferred_contact_method.id, 'name' => contribution.person.preferred_contact_method.name }},
                                'location' => nil,

--- a/spec/blueprints/contribution_blueprint_spec.rb
+++ b/spec/blueprints/contribution_blueprint_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe ContributionBlueprint do
         urgency_level_id: 1
     )
   end
+  let(:presenter) do
+    ContributionPresenter.new(contribution, double('ViewContext', contribution_path: '/fake/contribution/path'))
+  end
   let(:expected_contact_method) { contribution.person.preferred_contact_method }
   it 'returns reasonable data by default' do
     expected_area_name = Faker::Address.community
@@ -29,7 +32,7 @@ RSpec.describe ContributionBlueprint do
                                # "publish_until" => "2021-10-11",
                                # "publish_until_humanized" => "this year",
                                'created_at' => (contribution.created_at.to_f * 1000), # Javascript wants miliseconds, not seconds
-                               'view_path' => nil,
+                               'view_path' => '/fake/contribution/path',
                                'profile_path' => nil,
                                'match_path' => nil,
                                'name' => contribution.name,
@@ -44,19 +47,7 @@ RSpec.describe ContributionBlueprint do
                                'contact_types' => [{ 'id' => expected_contact_method.id, 'name' => expected_contact_method.name }]
                            }]
     }
-    result = ContributionBlueprint.render([contribution], root: 'contributions')
+    result = ContributionBlueprint.render([presenter], root: 'contributions')
     expect(JSON.parse(result)).to match(expected_data)
-  end
-
-  it 'allows injecting a url formatter for the view_path' do
-    expected_path = "/testing_#{contribution.id}"
-    result = ContributionBlueprint.render(contribution, view_path: ->(p_id) { "/testing_#{p_id}"})
-    expect(JSON.parse(result)['view_path']).to eq(expected_path)
-  end
-
-  it 'allows injecting a url formatter for the profile_path' do
-    expected_path = "/testing_#{contribution.person.id}"
-    result = ContributionBlueprint.render(contribution, profile_path: ->(p_id) { "/testing_#{p_id}"})
-    expect(JSON.parse(result)['profile_path']).to eq(expected_path)
   end
 end

--- a/spec/presenters/person_presenter_spec.rb
+++ b/spec/presenters/person_presenter_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe PersonPresenter do
+  let(:person)       { build :person, name: 'James Brown' }
+  let(:context)      { Context.new user: current_user  }
+  let(:view_context) { double 'ViewContext', context: context }
+  let(:presenter)    { PersonPresenter.new person, view_context }
+
+  describe 'name' do
+    subject { presenter.name }
+
+    context 'when current user is authorized to see people names' do
+      let(:current_user) { build :user, :admin }
+
+      it { is_expected.to eql 'James Brown' }
+    end
+
+    context 'when current user is not authorized to see people names' do
+      let(:current_user) { build :user, :neighbor }
+
+      it { is_expected.to be nil }
+    end
+  end
+end


### PR DESCRIPTION
### Why
This is a spike on top of #917 (and #951, #952) experimenting with using Presenters to solve the problem of conditionally showing attributes based on authorization policies.

### What, How
- [x] Add a `BasePresenter` with some functionality useful across presenters
- [x] Add a `present` helper method for use in erb templates
- [x] Fix a bug in `PersonPolicy` that allowed guest users access to any other Person w/o an associated user
- [x] Simplify the display of `person.name` on `/contributions` by not trying to split the name
- [x] Add `ContributionPresenter` and thread it into the serialization process in `ContributionsController#index`
- [x] Add `PersonPresenter`, use it in `ContributionPresenter` and have it conditionally show the name based on `PersonPolicy`.

Probably easiest to review each commit individually.
### Testing
Adds some specs for new code.

### Next Steps
- [ ] See thoughts below about how to support several conditional attribute.
- [ ] ?

### Outstanding Questions, Concerns and Other Notes
This solution works and feels like the right place to put logic.

However i wonder how it would scale when we need to conditionally show more than one attribute. Feels like we may need something analogous to `permitted_attributes` which lists all attributes allowed to be submitted, but in this case, a listing of attributes allowed to be shown. Maybe a `visible_attributes` method on the policy that could be used by the presenter to dynamically mask any disallowed attributes?

### Pre-Merge Checklist
- [x] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [ ] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
