### PR TITLE
Fix bug in PersonPolicy that allows guest to access other People

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,13 @@ We're still in the [initial development phase](https://www.jering.tech/articles/
 This changelog also serves to acknowledge the incredible people who've contributed brilliance, effort and being. Their handles are listed under the first release they each  touched. 💗🙏🏾
 
 ## [Unreleased]
-### Bugfixes
+### Security vulnerabilities fixed
+* Fix bug in authorization logic that allows a guest user to view names, emails, addresses of other people #951
+    * We recommend all installations update to this release IMMEDIATELY.
+
+### Other bugfixes
 * Fix breakage in claiming a contribution #946
+
 
 ## [0.5.0] - 2021-04-08
 ### Enhancements

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -35,6 +35,6 @@ class PersonPolicy < ApplicationPolicy
   end
 
   def own_person?
-    person.user_id == user&.id
+    person.user_id && person.user_id == user&.id
   end
 end

--- a/spec/policies/person_policy_spec.rb
+++ b/spec/policies/person_policy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PersonPolicy do
 
   let(:user)         { create(:user) }
   let(:own_person)   { create(:person, user: user) }
-  let(:other_person) { create(:person) }
+  let(:other_person) { create(:person, user: create(:user)) }
 
 
   context "given a normal signed-in user and their Person" do
@@ -91,6 +91,34 @@ RSpec.describe PersonPolicy do
 
     it "includes the person in its scope" do
       expect(resolved_scope).to include(person)
+    end
+  end
+
+  context "given a guest user and a different Person" do
+    let(:user) { nil }
+    let(:person) { other_person }
+
+    it { is_expected.to forbid_action(:show) }
+    it { is_expected.to forbid_new_and_create_actions }
+    it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_action(:destroy) }
+
+    it "does not includes the person in its scope" do
+      expect(resolved_scope).to_not include(person)
+    end
+  end
+
+  context "given a guest user and a Person without an associated User" do
+    let(:user) { nil }
+    let(:person) { create :person, user: nil }
+
+    it { is_expected.to forbid_action(:show) }
+    it { is_expected.to forbid_new_and_create_actions }
+    it { is_expected.to forbid_edit_and_update_actions }
+    it { is_expected.to forbid_action(:destroy) }
+
+    it "does not includes the person in its scope" do
+      expect(resolved_scope).to_not include(person)
     end
   end
 end


### PR DESCRIPTION
### Why
Discovered a bug while working on #950, extracted the fix here so it can be merged post haste.

### What
`PersonPolicy.own_person` was implemented as `person.user_id == user&.id`.
With a guest user, where user is nil, this works but only if person has a user; if it doesn't, then the two nils match and `own_person` returns true.

This effectively meant any guest user could access any Person record that didn't have an associated user record.
This is actually common because listings can be created by guests, in which case we generate a Person record w/o a user to associate it with.

To recreate, guest users need to guess the record id of a an existing `Person` record with no associated `User`.

### Testing
- [x] Added specs to cover this case in `person_policy_spec.rb`

### Next Steps
?

### Outstanding Questions, Concerns and Other Notes
?

### Security
I believe this fixes an existing vulnerability.

### Pre-Merge Checklist
- [x] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [x] Documentation and comments have been added to the codebase where required
- [x] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate