### PR TITLE
Presenter improvements

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -87,4 +87,9 @@ module ApplicationHelper
     # There should always be a current org, but being defensive here helps simplify tests
     context.host_organization&.logo_url.presence || asset_pack_path('media/images/logo.png')
   end
+
+  def present object, presenter_class
+    presenter = presenter_class.new object, self
+    block_given? ? yield(presenter) : presenter
+  end
 end

--- a/app/presenters/announcement_presenter.rb
+++ b/app/presenters/announcement_presenter.rb
@@ -1,4 +1,4 @@
-class AnnouncementPresenter < SimpleDelegator
+class AnnouncementPresenter < BasePresenter
   def expires_on
     return "This announcement does not expire." unless publish_until
 

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -1,5 +1,7 @@
 class BasePresenter < SimpleDelegator
   attr_reader :h
+  delegate :context, to: :h
+  alias_method :object, :__getobj__
 
   def initialize object, view_context
     super object

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -1,0 +1,8 @@
+class BasePresenter < SimpleDelegator
+  attr_reader :h
+
+  def initialize object, view_context
+    super object
+    @h = view_context
+  end
+end

--- a/app/views/announcements/show.html.erb
+++ b/app/views/announcements/show.html.erb
@@ -1,5 +1,7 @@
-<% announcement_presenter = AnnouncementPresenter.new(announcement) %>
+<% announcement_presenter = present announcement, AnnouncementPresenter %>
+
 <p id="notice"><%= notice %></p>
+
 <div class="card">
   <header class="card-header">
     <p class="card-header-title title is-3">

--- a/app/views/announcements/show.html.erb
+++ b/app/views/announcements/show.html.erb
@@ -1,11 +1,11 @@
-<% announcement_presenter = present announcement, AnnouncementPresenter %>
+<% present(announcement, AnnouncementPresenter) do |announcement| %>
 
 <p id="notice"><%= notice %></p>
 
 <div class="card">
   <header class="card-header">
     <p class="card-header-title title is-3">
-      <%= announcement_presenter.name %>
+      <%= announcement.name %>
       <% if policy(announcement).change? %>
         <%= link_to 'Edit', edit_announcement_path(announcement), class: "button is-primary ml-1" %>
       <% end %>
@@ -14,11 +14,11 @@
   <div class="card-content">
     <div class="content">
       <p>
-        <%= announcement_presenter.description %>
+        <%= announcement.description %>
       </p>
 
       <p>
-        <small><em><%= announcement_presenter.expires_on %></em></small>
+        <small><em><%= announcement.expires_on %></em></small>
       </p>
     </div>
   </div>
@@ -26,3 +26,5 @@
     <%= link_to 'Back', announcements_path, class: "button is-info ml-1 mt-1 mb-1" %>
   </div>
 </div>
+
+<% end %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#present' do
+    context 'without a block' do
+      subject(:presenter) { helper.present Object.new, AnnouncementPresenter }
+
+      it { is_expected.to be_an AnnouncementPresenter }
+
+      it 'passed view_context through to the presenter' do
+        expect(presenter.h).to be_a ActionView::Context
+      end
+    end
+
+    context 'with a block' do
+      it 'yields an instance of the presenter_class' do
+        expect { |b| helper.present Object.new, AnnouncementPresenter, &b }.to yield_with_args AnnouncementPresenter
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Why
Extracts some small improvements to our presenter code out of #950 

### What
- [x] Extract a `BasePresenter` providing convenience accessors and a default initializer
- [x] Add a `present` helper method that handles wiring `ActionView::Contex` into presenters
- [x] Refactor `announcements/show` to not neet the `_presenter` suffix

### Outstanding Questions, Concerns and Other Notes
?

### Pre-Merge Checklist
- [x] Security & accessibility are not impacted
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [x] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate