### PR TITLE
Lay groundwork for system specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,51 +1,49 @@
-docker_image: &docker_image
-  image: circleci/ruby:2.7.2-node
-
 version: 2.1
+
 commands:
   bundle_install:
-    description: 'Performs the bundler installation, relying on the CircleCI cache for performance'
+    description: 'Perform bundler installation, relying on CircleCI cache for performance'
     steps:
       - restore_cache:
           keys:
             - bundler-cache-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}
       - run:
-          name: 'Bundle Install'
+          name: 'Bundle install'
           command: |
             set -euxo pipefail
             bundle config set frozen 'true'
-            bin/bundle install --path=.bundle
+            bundle install --path=.bundle
       - save_cache:
           key: bundler-cache-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}
           paths:
             - .bundle
   yarn_install:
-    description: 'Performs node module installation, relying on the CircleCI cache for performance'
+    description: 'Perform node module installation, relying on CircleCI cache for performance'
     steps:
       - restore_cache:
           keys:
             - node-cache-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
       - run:
-          name: 'Yarn Modules Install'
+          name: 'Yarn install'
           command: bin/yarn install
       - save_cache:
           key: node-cache-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
-  rubocop:
-    description: 'Runs Rubocop'
+  run_rubocop:
+    description: 'Run rubocop'
     steps:
       - restore_cache:
           keys:
             - bundler-cache-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}
       - run:
-          name: Rubocop
+          name: 'Run rubocop'
           command: |
             set -euxo pipefail
-            bundle config path .bundle 
+            bundle config path .bundle
             bundle exec rubocop
-  rspec_tests:
-    description: 'Run the RSpec test suite'
+  rspec_backend:
+    description: 'Run rspec backend specs'
     steps:
       - restore_cache:
           keys:
@@ -54,83 +52,126 @@ commands:
           keys:
             - node-cache-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
       - run:
-          name: 'Run the RSpec Test Suite'
+          name: 'Run rspec backend specs'
           command: |
             set -euxo pipefail
             bundle config path .bundle
             bundle exec rails db:create
-            bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml
-  yarn_tests:
-    description: 'Run the Mocha test suite'
+            bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/rspec_backend/rspec.xml
+  mocha_specs:
+    description: 'Run mocha specs'
     steps:
       - restore_cache:
           keys:
             - node-cache-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
       - run:
-          name: 'Run the Mocha Test Suite'
+          name: 'Run mocha specs'
           command: yarn test --reporter mocha-junit-reporter
           environment:
-            MOCHA_FILE: test/test-results.xml
+            MOCHA_FILE: /tmp/frontend/test-results.xml
+  rspec_system:
+    description: 'Run rspec system specs'
+    steps:
+      - restore_cache:
+          keys:
+            - bundler-cache-{{ checksum ".ruby-version" }}-{{ checksum "Gemfile.lock" }}
+      - restore_cache:
+          keys:
+            - node-cache-{{ checksum "package.json" }}-{{ checksum "yarn.lock" }}
+      - run:
+          name: 'Run rspec system specs'
+          command: |
+            set -euxo pipefail
+            bundle config path .bundle
+            bundle exec rails db:create
+            bundle exec rails webpacker:compile
+            bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/rspec_system/rspec.xml spec/system
+
+app_image: &app_image
+  image: circleci/ruby:2.7.2-node-browsers
+db_image: &db_image
+  image: circleci/postgres:latest
 
 jobs:
   bundle:
     docker:
-      - <<: *docker_image
+      - <<: *app_image
     steps:
       - checkout
       - bundle_install
-  node_modules:
+  yarn:
     docker:
-      - <<: *docker_image
+      - <<: *app_image
     steps:
       - checkout
       - yarn_install
   rubocop:
     docker:
-      - <<: *docker_image
+      - <<: *app_image
     steps:
       - checkout
-      - rubocop
-  ruby_tests:
+      - run_rubocop
+  backend_specs:
     docker:
-      - <<: *docker_image
+      - <<: *app_image
         environment:
           RAILS_ENV: test
           POSTGRES_HOST: 127.0.0.1
-      - image: circleci/postgres:latest
+      - <<: *db_image
         environment:
           POSTGRES_USER: circleci
           POSTGRES_DB: mutualaid_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - checkout
-      - rspec_tests
+      - rspec_backend
       - store_test_results:
-          path: ~/rspec
-  js_tests:
+          path: /tmp/rspec_backend
+  frontend_specs:
     docker:
-      - <<: *docker_image
+      - <<: *app_image
     steps:
       - checkout
-      - yarn_tests
+      - mocha_specs
       - store_test_results:
-          path: test
+          path: /tmp/frontend
       - store_artifacts:
-          path: test
+          path: /tmp/frontend
+  system_specs:
+    docker:
+      - <<: *app_image
+        environment:
+          RAILS_ENV: test
+          POSTGRES_HOST: 127.0.0.1
+          HEADLESS_CHROME: true
+      - <<: *db_image
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_DB: mutualaid_test
+          POSTGRES_HOST_AUTH_METHOD: trust
+    steps:
+      - checkout
+      - rspec_system
+      - store_test_results:
+          path: /tmp/rspec_system
 
 workflows:
   version: 2.1
   mutual_aid:
     jobs:
       - bundle
-      - node_modules
+      - yarn
       - rubocop:
           requires:
             - bundle
-      - ruby_tests:
+      - backend_specs:
           requires:
             - bundle
-            - node_modules
-      - js_tests:
+            - yarn
+      - frontend_specs:
           requires:
-            - node_modules
+            - yarn
+      - system_specs:
+          requires:
+            - bundle
+            - yarn

--- a/Gemfile
+++ b/Gemfile
@@ -46,9 +46,10 @@ group :development, :test do
 end
 
 group :test do
-  # an XML formatter is required for fancier CircleCI results
-  gem 'rspec_junit_formatter'
+  gem 'capybara'
   gem 'pundit-matchers'
+  gem 'rspec_junit_formatter' # an XML formatter is required for fancier CircleCI results
+  gem 'selenium-webdriver'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     acts-as-taggable-on (6.5.0)
       activerecord (>= 5.0, < 6.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
@@ -73,6 +75,15 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.1)
+    capybara (3.35.3)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+    childprocess (3.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
@@ -136,6 +147,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    public_suffix (4.0.6)
     puma (5.3.1)
       nio4r (~> 2.0)
     pundit (2.1.0)
@@ -231,6 +243,10 @@ GEM
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
     ruby_http_client (3.5.0)
+    rubyzip (2.3.0)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
     sendgrid-ruby (6.2.0)
       ruby_http_client (~> 3.4)
@@ -273,6 +289,8 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -286,6 +304,7 @@ DEPENDENCIES
   blueprinter
   bootsnap (>= 1.4.2)
   byebug
+  capybara
   devise
   dotenv-rails
   factory_bot_rails
@@ -307,6 +326,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop-rails
   rubocop-rspec
+  selenium-webdriver
   sendgrid-ruby
   simple_form
   spring

--- a/bin/test
+++ b/bin/test
@@ -1,11 +1,14 @@
 #!/usr/bin/env ruby
 APP_ROOT = File.expand_path("..", __dir__)
 
-def system!(*args)
+def system!(message, *args)
+  puts('=' * 80, message) if message
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
 Dir.chdir(APP_ROOT) do
-  system! 'bin/rspec'
-  system! 'bin/yarn test'
+  system! '1/4 Running front-end specs', 'bin/yarn test'
+  system! '2/4 Recompiling webpack',     'RAILS_ENV=test bin/webpack'
+  system! '3/4 Running back-end specs',  'bin/rspec'
+  system! '4/4 Running system specs',    'HEADLESS_CHROME=true bin/rspec spec/system'
 end

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -1,10 +1,11 @@
 ## Running specs
-Running `bin/test` will run ruby tests (rspec) and then the js tests (mocha via mochapack) if all the rspec tests pass
+Running `bin/test` will run our complete test suite including front-end, back-end and system specs.
 
-To run front end tests and back end tests individually:
+To run each of these individully:
 
 * Front end: `yarn test` or `yarn test -w` (to watch for changes and rerun)
 * Back end: `bin/rspec` or `rerun bin/rspec spec/some/dir/or_spec.rb` (to watch for changes and rerun)
+* System specs: `bin/rspec spec/system`. Can be run in-browser or with headless chrome. See `spec/rails_helper.rb`.
 
 ## Request specs
 When writing rspec tests within the spec/request directory, you can use `Warden::Test:Helpers`

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,10 +52,6 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Warden::Test::Helpers
 
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
-  end
-
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.
@@ -79,5 +75,13 @@ RSpec.configure do |config|
   # https://github.com/wardencommunity/warden/wiki/Testing#requirements
   config.after type: :request do
     Warden.test_reset!
+  end
+
+  # exclude system specs unless they are the only ones specified
+  config.filter_run_excluding(type: :system) unless config.files_to_run.all? %r{/spec/system}
+
+  config.before(:example, type: :system) do
+    # set HEADLESS_CHROME in .env.test.local or when running rspec: HEADLESS_CHROME=true bin/rspec spec/system
+    driven_by(:selenium_chrome_headless) if ENV['HEADLESS_CHROME'] == 'true' # FIXME: use .to_boolean once merged
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ RSpec.configure do |config|
     # ...rather than:
     #     # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    expectations.syntax = :expect
   end
 
   # rspec-mocks config goes here. You can use an alternate test double
@@ -74,6 +75,7 @@ RSpec.configure do |config|
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
     config.default_formatter = 'doc'
+    config.order = :defined
   end
 
   # Print the 10 slowest examples and example groups at the

--- a/spec/system/registration_spec.rb
+++ b/spec/system/registration_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe 'Registration', type: :system do
+  before do
+    create(:organization, is_host: true)
+  end
+
+  it 'is able to load the landing page' do
+    visit '/'
+    expect(page.title).to eq 'Mutual-aid'
+  end
+end


### PR DESCRIPTION
### Why
We've been needing some system-level test coverage for a while now. This PR sets up the minimal groundwork needed to start writing them.

### What
- [x] Add necessary gems
- [x] Add first, nominal system spec
- [x] Configure rspec to not run system specs with non-system specs. Eg, invoking `bin/rspec` will exclude all system specs; to run them, all requested specs must be system specs, eg `bin/rspec spec/system`. 
- [x] Configure CirclCI to run system specs as a separate job
- [x] Provide ability to run specs with 'headless_chrome' based on an env. variable.

### Next Steps
With these changes, our `.circleci/config.yml` is in need of some refactoring; will follow up with a PR to address this.

### Outstanding Questions, Concerns and Other Notes
?

### Pre-Merge Checklist
- [x] Security & accessibility are not impacted
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [ ] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
