### PR TITLE
770 : Change the display of the navbar in many pages

### DIFF
--- a/app/controllers/community_resources_controller.rb
+++ b/app/controllers/community_resources_controller.rb
@@ -10,6 +10,7 @@ class CommunityResourcesController < ApplicationController
   end
 
   def show; end
+
   def edit; end
 
   def new

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -2,8 +2,6 @@
 
 # FIXME: Extract actions into separate controllers or consolidate with existing ones
 class PublicPagesController < PublicController
-  layout :determine_layout
-
   def about
     @about_us_text = HtmlSanitizer.new(@system_setting.about_us_text).sanitize
   end
@@ -26,11 +24,5 @@ class PublicPagesController < PublicController
       status: version,
       color: 'blue'
     }
-  end
-
-  private
-
-  def determine_layout
-    'without_navbar' unless @system_setting.display_navbar?
   end
 end


### PR DESCRIPTION
ref: #770
Sorry for my english.

### Why
When we change in the settings the display of the navbar, it impact undesired pages.

### What

- [x] Remove `determine_layout` in `PublicPagesController` to keep the navbar in about page, etc

### How
We can see the `determine_layout` feature to hide the navbar in the `AnnouncementsController`, `CommunityResourceController` and `PublicPagesController`.  When we change the display of the navbar to false, the pages managed by the `PublicPagesController` are impacted with this change so the navbar disappear.

### Testing
I don't know what to add the tests are still full green.

### Next Steps
Not seem to be concerned.

### Outstanding Questions, Concerns and Other Notes
Not seem to be concerned.

### Accessibility
Not seem to be concerned.

### Security
Not seem to be concerned.

### Meta
I have a very old computer and i can't run docker on it. I'm a newbie in Ruby, Rails, Webpack and had difficulty to understand that i need to have the webpack-dev-server running on the background to run the tests with the bin/test command. 

### Pre-Merge Checklist
I think the reviewer will check this so i let it empty.

- [ ] Security & accessibility have been considered
- [ ] Tests have been added, or an explanation has been given why the features cannot be tested
- [ ] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate

Best regards and stay safe !
