### PR TITLE
806 : the navbar is not displayed correctly

### DIFF
--- a/app/controllers/asks_controller.rb
+++ b/app/controllers/asks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AsksController < PublicController
-  layout 'without_navbar', only: %i[new create]
+  layout :determine_layout, only: %i[new create]
 
   def index
     redirect_to contributions_path
@@ -46,5 +46,9 @@ class AsksController < PublicController
     }.to_json
 
     render :new
+  end
+
+  def determine_layout
+    'without_navbar' unless context.system_settings.display_navbar?
   end
 end

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OffersController < PublicController
-  layout 'without_navbar', only: %i[new create]
+  layout :determine_layout, only: %i[new create]
 
   def index
     redirect_to contributions_path
@@ -46,5 +46,9 @@ class OffersController < PublicController
     }.to_json
 
     render :new
+  end
+
+  def determine_layout
+    'without_navbar' unless context.system_settings.display_navbar?
   end
 end


### PR DESCRIPTION
Sorry for my english.

### Why
The navbar is always hidden on `asks/new` and `offers/new` (#806).

### What
- [x] Display the navbar if the setting is on 

### How
The problem is that the navigation bar is still hidden because the option in settings is not used. We need to hide the navbar if the boolean is `false` like in other controllers.

### Testing
I don't know what to add.

### Next Steps
Unknown.

### Outstanding Questions, Concerns and Other Notes
Not seem to be concerned.

### Accessibility
Not seem to be concerned.

### Security
Not seem to be concerned.

### Meta
Not seem to be concerned.

### Pre-Merge Checklist
I think the reviewer will check this so i let it empty.

- [ ] Security & accessibility have been considered
- [ ] Tests have been added, or an explanation has been given why the features cannot be tested
- [ ] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
