### PR TITLE
Upgrade mochapack to fix source files not being auto-refreshed

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jsdom-global": "^3.0.2",
     "mocha": "^6",
     "mocha-junit-reporter": "^1.23.3",
-    "mochapack": "^1.1.15",
+    "mochapack": "^2.1.2",
     "prettier": "2.0.5",
     "release-it": "^13.6.2",
     "sinon": "9.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2541,7 +2541,7 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
-"chokidar@>=2.0.0 <4.0.0", chokidar@^3.4.1:
+"chokidar@>=2.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
   integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
@@ -2556,7 +2556,7 @@ check-error@^1.0.2:
   optionalDependencies:
     fsevents "~2.3.1"
 
-chokidar@^2.0.0, chokidar@^2.1.8:
+chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
@@ -6369,14 +6369,14 @@ mocha@^6:
     yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
 
-mochapack@^1.1.15:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/mochapack/-/mochapack-1.1.15.tgz#426c793b871ed006c781172da2b15f612f11f2dc"
-  integrity sha512-/gOsgJk3CWlNiOdef7hrNhp37VpatB9IiWzSCxS2p8pG21R7NAKJBBsU5T0eUWT9oz1NQhyubXdQgh51U7oVZA==
+mochapack@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/mochapack/-/mochapack-2.1.2.tgz#4732930e07c5ca8c27ac89767cd4946ffd2e6a22"
+  integrity sha512-Q8oo06XdNMzVIw/Ud6bs26fo8u3HBCx+CnzpdIaUiYdadW+B9dQ9C5B2bM8rGnUZ1HWTvrox2gRAHL8imFi9sw==
   dependencies:
     "@babel/runtime-corejs2" "^7.0.0"
     chalk "^2.4.2"
-    chokidar "^2.0.0"
+    chokidar "^3.5.1"
     glob-parent "5.1.0"
     globby "^10.0.1"
     interpret "^1.2.0"


### PR DESCRIPTION
### Why
With the previous version, changes to source files weren't being picked up in watch mode (`yarn test -w`).

### What
Simple upgrade. Couldn't find any definitive documentation but it appears the bug was related to a problem with having multiple available versions of the `chokidar` library.

### Outstanding Questions, Concerns and Other Notes
?

### Pre-Merge Checklist
- [x] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [x] Documentation and comments have been added to the codebase where required
- [x] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
