### PR TITLE
Adds a simple script to add a single user to the app

### DIFF
--- a/lib/tasks/add_user.rake
+++ b/lib/tasks/add_user.rake
@@ -1,0 +1,6 @@
+task add_user: :environment do
+  email = ENV['EMAIL']
+  password = ENV['PASSWORD']
+
+  User.create!(email: email, password: password, password_confirmation: password, confirmed_at: Time.current)
+end


### PR DESCRIPTION
### Why

Previously there has not been an easy way to add a new user to the application prior to configuring a SMTP server to dispatch confirmation emails.

### What

Create a rake task that
- [x]  May be invoked as `bin/rake add_user EMAIL=example@exampler.com PASSWORD=mysupersecurepassword`
- [x] Takes exactly the command line arguments `EMAIL` and `PASSWORD`
- [x] Creates the user immediately, with no need for any additional confirmation 

### How

Omitted, as this was a very simple change.

### Testing

Omitted, as this task is only meant to be run by developers in non-production environments

### Next Steps

1. Add a simple test to ensure syntactic/semantic comparability over time.
2. Perhaps add a safety check to ensure that developers must manually specify, similar to `DISABLE_DATABASE_ENVIRONMENT_CHECK=1`

### Accessibility

Omitted, as this is a developer-only feature.

### Security

This script cannot be run without administrator shell access to the server hosting the application, and anyone who has administrator shell access to the server is able to do anything they want. Therefore, security of this script isn't really relevant since any scenario where this is invoked by a bad actor is also a scenario where the bad actor can do arbitrary other things.

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [ ] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate

Also, thanks to @h-m-m for their help making this change!
