### PR TITLE
Change button text on Claim page for Ask

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -90,6 +90,10 @@ class Listing < ApplicationRecord
     type == 'Offer'
   end
 
+  def claim_button_text
+    ask? ? "Help this person" : "Claim this offer"
+  end
+
   def icon_class
     if ask?
       'fa fa-hand-sparkles'

--- a/app/views/claims/new.html.erb
+++ b/app/views/claims/new.html.erb
@@ -1,5 +1,5 @@
 <section>
-  <%= content_tag(:h1, "Claim This #{contribution.type}", class: "title") %>
+  <%= content_tag(:h1, "#{contribution.claim_button_text}", class: "title") %>
   <div class="box">
     <p class='block'>
       The information you enter below will be sent to the other party.

--- a/app/views/claims/new.html.erb
+++ b/app/views/claims/new.html.erb
@@ -1,5 +1,5 @@
 <section>
-  <%= content_tag(:h1, "#{contribution.claim_button_text}", class: "title") %>
+  <%= content_tag(:h1, contribution.claim_button_text, class: "title") %>
   <div class="box">
     <p class='block'>
       The information you enter below will be sent to the other party.

--- a/app/views/contributions/_top_level_card.html.erb
+++ b/app/views/contributions/_top_level_card.html.erb
@@ -14,9 +14,9 @@
           <i class="far fa-check-circle has-text-primary is-size-5 has-text-weight-semibold"><span class="ml-1">Claimed</span></i>
         <% else %>
           <% if contribution.has_email? %>
-            <%= button_to "Claim This #{contribution.type}", new_contribution_claim_path(contribution), class: "button is-primary", method: :get %>
+            <%= button_to "#{contribution.claim_button_text}", new_contribution_claim_path(contribution), class: "button is-primary", method: :get%>
           <% else %>
-            <button class="button is-primary" disabled="true">Claim This <%= contribution.type %></button>
+            <button class="button is-primary" disabled="true"><%= contribution.claim_button_text %></button>
             <p class="is-6 is-italic">This person has not yet entered contact information so that you can claim this contribution. You may need to check back later</p>
           <% end %>
         <% end %>

--- a/app/views/contributions/_top_level_card.html.erb
+++ b/app/views/contributions/_top_level_card.html.erb
@@ -14,7 +14,7 @@
           <i class="far fa-check-circle has-text-primary is-size-5 has-text-weight-semibold"><span class="ml-1">Claimed</span></i>
         <% else %>
           <% if contribution.has_email? %>
-            <%= button_to "#{contribution.claim_button_text}", new_contribution_claim_path(contribution), class: "button is-primary", method: :get%>
+            <%= button_to contribution.claim_button_text, new_contribution_claim_path(contribution), class: "button is-primary", method: :get%>
           <% else %>
             <button class="button is-primary" disabled="true"><%= contribution.claim_button_text %></button>
             <p class="is-6 is-italic">This person has not yet entered contact information so that you can claim this contribution. You may need to check back later</p>

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -33,4 +33,15 @@ RSpec.describe Listing, type: :model do
       expect(listing.has_email?).to eq(false)
     end
   end
+
+  describe 'claim button text' do
+    example 'when listing is an offer' do
+      expect(listing.claim_button_text).to eq ('Claim this offer')
+    end
+
+    example 'when listing is an ask' do
+      listing = build(:ask, person: create(:person))
+      expect(listing.claim_button_text).to eq ('Help this person')
+    end
+  end
 end

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -36,12 +36,12 @@ RSpec.describe Listing, type: :model do
 
   describe 'claim button text' do
     example 'when listing is an offer' do
-      expect(listing.claim_button_text).to eq ('Claim this offer')
+      expect(listing.claim_button_text).to eq('Claim this offer')
     end
 
     example 'when listing is an ask' do
       listing = build(:ask, person: create(:person))
-      expect(listing.claim_button_text).to eq ('Help this person')
+      expect(listing.claim_button_text).to eq('Help this person')
     end
   end
 end


### PR DESCRIPTION
### Why

Hi! I'm new here. This is my PR to modify the button text for Asks: https://github.com/rubyforgood/mutual-aid/issues/871

<img width="1178" alt="Screen Shot 2021-10-04 at 9 20 06 PM" src="https://user-images.githubusercontent.com/25471753/135945610-4473e6dc-dc06-4179-ab1c-518b95cd164a.png">

### What

I've changed the button copy for claiming listings. When it's an ask, copy is `Help this person` (proposed change in https://github.com/rubyforgood/mutual-aid/issues/871) and when it's an offer `Claim this offer` (no change from previous version). 

### How

Because both `Offer` and `Ask` inherit from `Listing`, I've created a method `Listing#claim_button_text` that can be called by both types and returns the correct button copy. 

### Testing

This is a pretty minor UI change but I've written a spec that covers both cases. 

### Next Steps

N/A

### Outstanding Questions, Concerns and Other Notes

N/A 

### Accessibility

This change doesn't affect or worsen the existing accessibility.

### Security

I don't think this change has any security implications. 

### Meta

N/A

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [x] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [ ] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
