### PR TITLE
Make NavBarPolicy allow Feedback only for Admins

### DIFF
--- a/app/policies/nav_bar_policy.rb
+++ b/app/policies/nav_bar_policy.rb
@@ -3,15 +3,8 @@ class NavBarPolicy < ApplicationPolicy
     visible = Set.new
     visible << (user ? 'Logout' : 'Login')
     visible << 'Sign Up' unless user
-    visible << 'Feedback' if is_admin?(user)
     visible.merge %w[Glossary Contributions] if system_settings.peer_to_peer?
-    visible.merge %w[Contributions Matches Admin] if can_admin?
+    visible.merge %w[Contributions Feedback Matches Admin] if can_admin?
     visible.to_a
-  end
-
-  private
-
-  def is_admin?(user)
-    user && (user.admin_role? || user.sys_admin_role?)
   end
 end

--- a/app/policies/nav_bar_policy.rb
+++ b/app/policies/nav_bar_policy.rb
@@ -3,9 +3,15 @@ class NavBarPolicy < ApplicationPolicy
     visible = Set.new
     visible << (user ? 'Logout' : 'Login')
     visible << 'Sign Up' unless user
-    visible << 'Feedback' if user
+    visible << 'Feedback' if is_admin?(user)
     visible.merge %w[Glossary Contributions] if system_settings.peer_to_peer?
     visible.merge %w[Contributions Matches Admin] if can_admin?
     visible.to_a
+  end
+
+  private
+
+  def is_admin?(user)
+    user && (user.admin_role? || user.sys_admin_role?)
   end
 end

--- a/spec/policies/nav_bar_policy_spec.rb
+++ b/spec/policies/nav_bar_policy_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe NavBarPolicy do
     context 'neighbor' do
       let(:user) { instance_double 'User', admin_role?: false, sys_admin_role?: false }
 
-      it { is_expected.to match_array %w[Feedback Logout] }
+      it { is_expected.to match_array %w[Logout] }
 
       context 'in peer_to_peer mode' do
         let(:peer_to_peer?) { true }
-        it { is_expected.to match_array %w[Glossary Contributions Feedback Logout] }
+        it { is_expected.to match_array %w[Glossary Contributions Logout] }
       end
     end
 


### PR DESCRIPTION
### Why
To fix #992, show the `Feedback` NavBar button only to Admins & Sys-Admins

I chose those approach after seeing that the route triggered by the `Feedback` button uses the `SoftwareFeedbacksController` is derived from `AdminController`, which allows actions only by users with either the `admin` or `sys_admin` role. That is, I inferred the UI was incorrectly offering the button.

### What
Change `NavBarPolicy#visible_buttons` to include `Feedback` only for `User`s with either the `admin` or `sys_admin`.

### How
Moved adding `Feedback` to the allow-list from the line with `NavBarPolicy#visible_buttons`'s simple non-`nil` check to the line guarded with the call to `ApplicationPolicy#can_admin?`

### Testing
The PR modifies existing examples, removing the expectation for `Feedback`'s presence for `neighbor` cases.

#### With modified examples, without modified code - 2 failures
<img width="1172" alt="image" src="https://user-images.githubusercontent.com/2031462/142676552-fe622e42-76fc-48bc-b7db-ed1be7414085.png">

#### With modified examples & code - 0 failures
<img width="524" alt="image" src="https://user-images.githubusercontent.com/2031462/142676907-d361df09-2254-49a3-9f90-9e4f8f7e6001.png">

#### Rubocop - no change
<img width="1223" alt="image" src="https://user-images.githubusercontent.com/2031462/142682793-66f2f435-ed52-4418-add7-a991fe7d1b06.png">

### Outstanding Questions, Concerns and Other Notes
More about the specs than the bug: in my dev/repro environment, I noticed that my new `User` had the `unset` role. This was different from `neighbor`, but both are "neither `admin` nor `sys_admin`", so I simply modified the existing `context`s.

### Accessibility
None that I'm aware of.

### Security
Very slight improvement—now the UI "advertises" one fewer route to non-{,sys}admin users.

### Meta

This is my first PR here.
I hope/believe I have read and understood the various guides, policies, etc. (humble apologies if not...)
Constructive feedback welcome, of course.

### Pre-Merge Checklist
<!-- All these boxes should be checked off before any pull request is merged! -->

- [ ] Security & accessibility have been considered
- [ ] Tests have been added, or an explanation has been given why the features cannot be tested
- [ ] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
