### PR TITLE
Add Procfile.dev and instructions for its use.

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,3 @@
+mail: mailcatcher -f
+pack: bin/webpack-dev-server
+web: bin/rails server

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -141,19 +141,27 @@ Remember to configure environment variables in Heroku or wherever you deploy!
 Only the development environment uses `.env` files.
 
 
-## Running the App!
+## Running the app!
 
 First, make sure local services or docker are running.
 
-Then, to run the app locally:
+Before starting the app for the first time, you'll want to:
 ```
 $ bundle && yarn
 $ bin/rake db:rebuild_and_seed_dev
-$ bin/rails s # or, rails s -p 9000 (or whatever port you want to use that's not the default 3000)
 ```
-And in a separate terminal:
+Which will seed the development db with necessary accounts and some test data.
+
+In development, running the app involves firing up several processes, which are defined in [Procfile.dev](Procfile.dev). You can manage these processes yourself, by invoking each of them in separate terminals (or backgrounding them). For example, run
+* `bin/rails server` in one terminal and
+* `bin/webpack-dev-server` in another.
+* Note that `mailcatcher` is only necessary for some features and can also be skipped (see [.env](.env)).
+
+Alternatively, you can use a process manager such as [foreman](https://github.com/ddollar/foreman), [invoker](https://invoker.codemancers.com/), [node-foreman](https://github.com/strongloop/node-foreman), etc., eg one of:
 ```
-$ bin/webpack-dev-server
+$ foreman start -f Procfile.dev
+$ invoker start Procfile.dev
+$ nf start -f Procfile.dev
 ```
 
 You should now be able to see the app running at http://localhost:3000 (or whichever port the rails server is running on).


### PR DESCRIPTION
Simplify local development by defining the processes involved in a new `Procfile.dev`. This file is compatible with several process managers such as [foreman](https://github.com/ddollar/foreman), [invoker](https://invoker.codemancers.com/) and [node-foreman](https://github.com/strongloop/node-foreman).

### Some considerations worth noting:
1. I looked into the possibility of using the existing `Procfile` for both production and development. This would've required adding intelligence to startup scripts such as `bin/webpack-dev-server` so that they would no-op in production. Turned out to be more complicated because `foreman` interprets any early process exit as an error and aborts all processes.
1. I chose not to introduce a convenience script such as `bin/serve` for a few reasons:
    1. I didn't want to assume/prescribe a specific process manager such as `foreman`.
    2. It's easy for engineers to create a shell alias or git-ignored script with their preferred process manager and startup options.

As such, while this `Procfile.dev` hopefully simplifies initial setup for a new contributor, i see its primary purpose as defining the processes involved more so than prescribing a canonical way of invoking them.