### PR TITLE
Constrain supported node engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ We're still in the [initial development phase](https://www.jering.tech/articles/
 
 This changelog also serves to acknowledge the incredible people who've contributed brilliance, effort and being. Their handles are listed under the first release they each  touched. 💗🙏🏾
 
+## [Unreleased]
+
+### Bugfixes
+* Constrain supported nodejs engines #1000
+
 ## [0.6.0] - 2021-12-14
 
 ### Breaking change / enhancement

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.6.0",
   "engines": {
-    "node": ">= 14.0.0",
+    "node": ">= 14.0.0 < 17",
     "yarn": "^1.20.0"
   },
   "dependencies": {


### PR DESCRIPTION
Ran into the following issue with node v17:
https://github.com/webpack/webpack/issues/14532

There are other workarounds but i figure this is safer for now, at least until we are able to #906.