### PR TITLE
Compose field name

### DIFF
--- a/app/javascript/components/forms/ContactFields.vue
+++ b/app/javascript/components/forms/ContactFields.vue
@@ -35,7 +35,7 @@
 
 <script>
 import {partial} from 'utils/function'
-import {fieldNameWithPrefix} from 'utils/form'
+import {composeFieldName} from 'utils/form'
 
 export default {
   props: {
@@ -47,7 +47,7 @@ export default {
     const preference = this.person.preferred_contact_method
     return {
       preferredContactMethodId: preference ? preference.id : null,
-      withPrefix: partial(fieldNameWithPrefix, this.fieldNamePrefix),
+      withPrefix: partial(composeFieldName, this.fieldNamePrefix),
     }
   },
   computed: {

--- a/app/javascript/components/forms/CustomQuestions.vue
+++ b/app/javascript/components/forms/CustomQuestions.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script>
-import {fieldNameWithPrefix} from 'utils/form'
+import {composeFieldName} from 'utils/form'
 
 export default {
   props: {
@@ -22,7 +22,7 @@ export default {
   },
   methods: {
     fieldName(id) {
-      return fieldNameWithPrefix(this.fieldNamePrefix, id.toString())
+      return composeFieldName(this.fieldNamePrefix, id.toString())
     },
   },
 }

--- a/app/javascript/components/forms/LocationFields.vue
+++ b/app/javascript/components/forms/LocationFields.vue
@@ -31,7 +31,7 @@
 <script>
 import {partial} from 'utils/function'
 import {capitalize, replace} from 'utils/string'
-import {fieldNameWithPrefix} from 'utils/form'
+import {composeFieldName} from 'utils/form'
 
 export default {
   props: {
@@ -46,8 +46,7 @@ export default {
     }
   },
   created: function() {
-    // TODO: tiny bit of duplication with partial+fieldNameWithPrefix
-    this.withPrefix = partial(fieldNameWithPrefix, this.fieldNamePrefix)
+    this.withPrefix = partial(composeFieldName, this.fieldNamePrefix)
   },
   filters: {
     capitalize,

--- a/app/javascript/components/forms/LocationFields.vue
+++ b/app/javascript/components/forms/LocationFields.vue
@@ -1,21 +1,21 @@
 <template>
   <div>
     <b-field
-      :label-for="withPrefix('street_address')"
+      :label-for="fieldName('street_address')"
       label="Street address"
       custom-class="is-medium"
     >
-      <b-input :name="withPrefix('street_address')" v-model="streetAddress" />
+      <b-input :name="fieldName('street_address')" v-model="streetAddress" />
     </b-field>
 
     <b-field
       v-if="streetAddress.length"
-      :label-for="withPrefix('location_type')"
+      :label-for="fieldName('location_type')"
       label="Address type"
       custom-class="required-field is-medium"
     >
       <b-select
-        :name="withPrefix('location_type')"
+        :name="fieldName('location_type')"
         :value="location_type.id"
         placeholder="Type"
         required
@@ -46,7 +46,7 @@ export default {
     }
   },
   created: function() {
-    this.withPrefix = partial(composeFieldName, this.fieldNamePrefix)
+    this.fieldName = partial(composeFieldName, this.fieldNamePrefix)
   },
   filters: {
     capitalize,

--- a/app/javascript/pages/Ask.vue
+++ b/app/javascript/pages/Ask.vue
@@ -34,7 +34,7 @@
     /><SpacerField />
 
     <CategoryFields
-      :fieldNamePrefix="withListingPrefix('categories[]')"
+      :fieldNamePrefix="withListingPrefix('categories', '[]')"
       :categories="configuration.categories"
       :tags="listing.tag_list"
     >
@@ -56,7 +56,7 @@
 
 <script>
 import {partial} from 'utils/function'
-import {fieldNameWithPrefix} from 'utils/form'
+import {composeFieldName} from 'utils/form'
 import {
   AuthTokenInput,
   CategoryFields,
@@ -98,8 +98,8 @@ export default {
     }
   },
   created: function() {
-    this.withListingPrefix = partial(fieldNameWithPrefix, 'submission[listings_attributes]')
-    this.withPersonPrefix  = partial(fieldNameWithPrefix, 'submission[person_attributes]')
+    this.withListingPrefix = partial(composeFieldName, 'submission', 'listings_attributes')
+    this.withPersonPrefix  = partial(composeFieldName, 'submission', 'person_attributes')
   },
 }
 </script>

--- a/app/javascript/pages/Offer.vue
+++ b/app/javascript/pages/Offer.vue
@@ -34,7 +34,7 @@
     /><SpacerField />
 
     <CategoryFields
-      :fieldNamePrefix="withListingPrefix('categories[]')"
+      :fieldNamePrefix="withListingPrefix('categories', '[]')"
       :categories="configuration.categories"
       :tags="listing.tag_list"
     >
@@ -73,7 +73,7 @@
 
 <script>
 import {partial} from 'utils/function'
-import {fieldNameWithPrefix} from 'utils/form'
+import {composeFieldName} from 'utils/form'
 import {
   AuthTokenInput,
   CategoryFields,
@@ -125,8 +125,8 @@ export default {
     }
   },
   created: function() {
-    this.withListingPrefix = partial(fieldNameWithPrefix, 'submission[listings_attributes]')
-    this.withPersonPrefix  = partial(fieldNameWithPrefix, 'submission[person_attributes]')
+    this.withListingPrefix = partial(composeFieldName, 'submission', 'listings_attributes')
+    this.withPersonPrefix  = partial(composeFieldName, 'submission', 'person_attributes')
   },
   skillsMessage,
 }

--- a/app/javascript/utils/form.js
+++ b/app/javascript/utils/form.js
@@ -1,7 +1,15 @@
-export function fieldNameWithPrefix(prefix, name) {
-  if (!prefix || !prefix.length) return name
+export function composeFieldName(preceding, current, ...subsequent) {
+  if (!current) return preceding
 
-  return name.endsWith('[]')
-    ? `${prefix}[${name.slice(0, -2)}][]`
-    : `${prefix}[${name}]`
+  if (preceding && preceding.length) {
+    const combined =
+      current === '[]' ?
+      `${preceding}[]` :
+      `${preceding}[${current}]`
+
+    return composeFieldName(combined, ...subsequent)
+  }
+  else {
+    return composeFieldName(current, ...subsequent)
+  }
 }

--- a/spec/javascript/utils/form.spec.js
+++ b/spec/javascript/utils/form.spec.js
@@ -1,27 +1,22 @@
-import {partial} from 'utils/function'
-import {fieldNameWithPrefix} from 'utils/form'
+import {composeFieldName} from 'utils/form'
 
 describe('form utils', () => {
-  describe('fieldNameWithPrefix', () => {
-    describe('without a prefix', () => {
-      it('returns the field name given', () => {
-        assert.equal(fieldNameWithPrefix(null, 'field'), 'field')
-        assert.equal(fieldNameWithPrefix('',   'field'), 'field')
-      })
+  describe('composeFieldName', () => {
+    it('returns the field with a rails style prefix', () => {
+      assert.equal(composeFieldName('prefix', 'field'), 'prefix[field]')
     })
 
-    describe('with a prefix', () => {
-      def('withPrefix', () => partial(fieldNameWithPrefix, 'prefix'))
+    it('appends all segments given', () => {
+      assert.equal(composeFieldName('prefix', 'two', 'segments'), 'prefix[two][segments]')
+    })
 
-      it('returns the field with a rails style prefix', () => {
-        assert.equal($withPrefix('field'), 'prefix[field]')
-      })
+    it('understands an array signifier', () => {
+      assert.equal(composeFieldName('prefix', 'arrayField', '[]'), 'prefix[arrayField][]')
+    })
 
-      describe('an array field', () => {
-        it('correctly appends the bracket', () => {
-          assert.equal($withPrefix('arrayField[]'), 'prefix[arrayField][]')
-        })
-      })
+    it('ignores a missing prefix and combines other segments given', () => {
+      assert.equal(composeFieldName(null, 'field'), 'field')
+      assert.equal(composeFieldName('',   'one', 'two'), 'one[two]')
     })
   })
 })


### PR DESCRIPTION
### Why
Enhances `fieldNameWithPrefix` utility function so it can support multiple segments in the field name.

Mostly wanted to rescue this useful change from a wip branch that probably won't get merged in.

### What
Renames the function as `composeFieldName` and makes the implementation recursive.

In combination with the `partial` function, allows components to generate field names for deeply nested attributes.

### Testing
Enhanced existing unit test.

### Pre-Merge Checklist
- [x] Security & accessibility have been considered
- [x] Tests have been added, or an explanation has been given why the features cannot be tested
- [x] Documentation and comments have been added to the codebase where required
- [x] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
