### PR TITLE
Experiment with moving serialization out of Filter classes

### DIFF
--- a/app/blueprints/contribution_type_filter_option_blueprint.rb
+++ b/app/blueprints/contribution_type_filter_option_blueprint.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ContributionTypeFilterOptionBlueprint < Blueprinter::Base
+  identifier :id do |filter_option|
+    "ContributionType[#{filter_option}]"
+  end
+
+  field :name do |filter_option|
+    filter_option.titleize
+  end
+end

--- a/app/blueprints/filter_group_blueprint.rb
+++ b/app/blueprints/filter_group_blueprint.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FilterGroupBlueprint < Blueprinter::Base
+  field :filter_grouping_name, name: :name
+
+  association :filter_options, blueprint: ->(filter_options) do
+    if filter_options == ContributionTypeFilter.filter_options
+      ContributionTypeFilterOptionBlueprint
+    else
+      FilterOptionBlueprint
+    end
+  end
+end

--- a/app/filters/category_filter.rb
+++ b/app/filters/category_filter.rb
@@ -1,10 +1,10 @@
 class CategoryFilter < BaseFilter
-  def self.filter_grouping
-    {
-      name: "Categories",
-      # Currently only filtering by top-level categories
-      filter_options: FilterOptionBlueprint.render_as_hash(Category.roots)
-    }
+  def self.filter_grouping_name
+    'Categories'
+  end
+
+  def self.filter_options
+    Category.roots
   end
 
   def filter(scope)

--- a/app/filters/contact_method_filter.rb
+++ b/app/filters/contact_method_filter.rb
@@ -1,9 +1,10 @@
 class ContactMethodFilter < BaseFilter
-  def self.filter_grouping
-    {
-      name: 'Contact Methods',
-      filter_options: FilterOptionBlueprint.render_as_hash(ContactMethod.enabled.distinct(:name))
-    }
+  def self.filter_grouping_name
+    'Contact Methods'
+  end
+
+  def self.filter_options
+    ContactMethod.enabled.distinct(:name)
   end
 
   def filter(scope)

--- a/app/filters/contribution_type_filter.rb
+++ b/app/filters/contribution_type_filter.rb
@@ -1,11 +1,12 @@
 class ContributionTypeFilter < BaseFilter
-  def self.filter_grouping
-    {name: 'Contribution Types', filter_options: [
-      {id: 'ContributionType[Ask]', name: 'Ask'},
-      {id: 'ContributionType[Offer]', name: 'Offer'},
-      {id: 'ContributionType[CommunityResource]', name: 'Community Resource'}
-    ]}
+  def self.filter_grouping_name
+    'Contribution Types'
   end
+
+  def self.filter_options
+    ALL_ALLOWED_TYPES
+  end
+
   ALL_ALLOWED_TYPES = %w[Ask Offer CommunityResource].freeze
 
   def filter(scope)

--- a/app/filters/service_area_filter.rb
+++ b/app/filters/service_area_filter.rb
@@ -1,9 +1,10 @@
 class ServiceAreaFilter < BaseFilter
-  def self.filter_grouping
-    {
-      name: 'Service Areas',
-      filter_options: FilterOptionBlueprint.render_as_hash(ServiceArea.i18n)
-    }
+  def self.filter_grouping_name
+    'Service Areas'
+  end
+
+  def self.filter_options
+    ServiceArea.i18n
   end
 
   def filter(scope)

--- a/app/models/browse_filter.rb
+++ b/app/models/browse_filter.rb
@@ -18,7 +18,7 @@ class BrowseFilter
   attr_reader :parameters
 
   def self.filter_groupings_json
-    FILTER_CLASSES.map(&:filter_grouping).to_json
+    FilterGroupBlueprint.render(FILTER_CLASSES)
   end
 
   def initialize(parameters)


### PR DESCRIPTION
### Why
This allows us to extract serialization out of the Filter classes, leaving it appropriately in the controller -> serialization layer.

### What
Introduces a `FilterGroupBlueprint` which dynamically determines whether to use a regular `FilterOptionBlueprint` or the special case `ContributionTypeFilterOptionBlueprint`.

### Testing
Covered by existing tests.

### Outstanding Questions, Concerns and Other Notes
?

### Meta
@h-m-m , this came out of a pairing discussion we had many months ago. I remember spiking this out and found the branch lying around. Figured i'd bring it up to date and put up a PR. Totally happy to close this out though if this direction doesn't feel right.

### Pre-Merge Checklist
- [ ] Security & accessibility have been considered
- [ ] Tests have been added, or an explanation has been given why the features cannot be tested
- [ ] Documentation and comments have been added to the codebase where required
- [ ] Entry added to CHANGELOG.md if appropriate
- [ ] Outstanding questions and concerns have been resolved
- [ ] Any next steps have been turned into Issues or Discussions as appropriate
